### PR TITLE
fix(ci): pre-release gate for slow Paketo/CVE scans not in `make ci`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,3 +29,7 @@ Thumbs.db
 
 # mermaid-lint scratch outputs
 docs/diagrams/out/.mermaid-lint-*.png
+
+# Claude Code transient state
+.claude/scheduled_tasks.lock
+.claude/settings.local.json

--- a/.trivyignore
+++ b/.trivyignore
@@ -1,0 +1,29 @@
+# Trivy ignore list
+#
+# Scope: applies to `make image-scan` (OCI image scanning) and `make trivy-fs`
+# (filesystem scanning). trivy picks this file up automatically from the
+# working directory.
+#
+# Suppression policy:
+#   - Every entry requires a CVE ID, a one-line reason, and an upstream tracker.
+#   - Re-evaluate the list after every Paketo buildpack / base-image refresh.
+#     If the CVE drops off a new image scan, remove the entry.
+#
+# ------------------------------------------------------------
+# Paketo buildpack helper binaries — Go stdlib 1.26.1
+# ------------------------------------------------------------
+# These CVEs live in tiny Go helpers baked into every spring-boot:build-image
+# output:
+#     /layers/paketo-buildpacks_ca-certificates/helper/helper
+#     /layers/paketo-buildpacks_spring-boot/helper/helper
+# They run ONCE at container start (symlink setup + JVM launcher) and are not
+# reachable from application request paths. Fix is exclusively upstream:
+# Paketo must rebuild their buildpacks against Go 1.26.2+. Once they do, the
+# next `mvn spring-boot:build-image` will pull a refreshed layer and these
+# entries become dead code — remove them.
+#
+# Upstream tracker: https://github.com/paketo-buildpacks/spring-boot/issues
+#                   https://github.com/paketo-buildpacks/ca-certificates/issues
+CVE-2026-32280
+CVE-2026-32282
+CVE-2026-33810

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -54,7 +54,8 @@ make deps-helm                          # Install helm binary
 make print-deps-updates                 # Print project dependencies updates
 make update-deps                        # Update project dependencies to latest releases
 make renovate-validate                  # Validate Renovate configuration
-make release VERSION=x.y.z              # Create a semver release tag (run `make cve-check` first)
+make pre-release                        # Runs cve-check (advisory) + image-scan (strict). Required before `make release`
+make release VERSION=x.y.z              # Create a semver release tag (auto-runs `make pre-release`)
 ```
 
 ### Test pyramid
@@ -167,6 +168,7 @@ Last reviewed: 2026-04-20
 - [x] **Paketo/CNB builder blind spot — added `image-scan` target** — `make image-scan` runs `trivy image --severity HIGH,CRITICAL` against each `pizza-*:e2e` OCI image after `image-build`. Wired into the `e2e` job so CI fails on layer-level CVEs that `trivy-fs` (filesystem) and `cve-check` (Maven deps) both miss. (2026-04-20)
 - [x] **Dapr Helm bump to 1.17.5** — chart now at 1.17.5 via `DAPR_HELM_VERSION`. Java SDK/testcontainers-dapr stay at 1.17.2 (latest stable on Maven Central; `io.dapr.spring:dapr-spring-boot-4-starter` 1.17.3 is RC-only — re-visit on GA). Runtime-ahead-of-SDK is the normal Dapr Java cadence. (2026-04-20)
 - [x] **`salaboy/pizza-*:0.1.0` prod images retired** — manifests (`k8s/pizza-*.yaml`, `k8s-dapr-shared/apps.yaml`) now reference `ghcr.io/andriykalashnykov/pizza-*:0.1.0`. (1) First-party build pipeline: new `publish-images` job in `ci.yml`, tag-gated, runs after e2e, uses `make image-scan` to build + scan, pushes `:<version>` and `:latest` to GHCR. (2) One-shot mirror: `scripts/mirror-salaboy-images.sh` (exposed as `make mirror-images`) copies the current upstream `:0.1.0` bits into your GHCR so the manifests resolve today; run once after `docker login ghcr.io`. Renovate `kubernetes` manager now enabled (`renovate.json`) so manifest image tags are auto-tracked. (2026-04-20)
+- [x] **Pre-release gate closes image-scan blind spot** — `make ci` and `make ci-run` do NOT exercise `image-scan` (it lives downstream of `kind-deploy`). First v0.1.0 tag push failed in CI when Trivy found 3 HIGH Go-stdlib CVEs in Paketo helper binaries that no local gate ever ran against. Fix: new `make pre-release` bundles every slow gate missing from `make ci` — `cve-check` (advisory; mirrors CI's `continue-on-error` until the OWASP NVD deserializer bug is fixed upstream) + `image-scan` (strict). `make release` depends on `pre-release`, so a tag cannot be written without the scan gate passing. `.trivyignore` documents the currently-accepted Paketo-upstream CVEs with the reasoning + tracker links required for removal. (2026-04-20)
 
 ## Skills
 

--- a/Makefile
+++ b/Makefile
@@ -540,8 +540,21 @@ e2e: kind-up
 	@# Uncomment the next line to auto-teardown on success:
 	@# $(MAKE) kind-down
 
+#pre-release: @ Run every slow gate that's NOT in `make ci` (cve-check + image-scan). Required before `make release`.
+pre-release:
+	@# cve-check is advisory pending the upstream NVD deserializer bug
+	@# (dependency-check/DependencyCheck issue, tracked in CLAUDE.md). Mirrors
+	@# the CI workflow's `continue-on-error: true` on the same step.
+	@$(MAKE) cve-check || echo "WARN: cve-check failed — see CLAUDE.md backlog (OWASP NVD deserializer bug). Continuing pre-release."
+	@# image-scan is the hard gate that caught Paketo CVEs post-push before.
+	@$(MAKE) image-scan
+	@echo "Pre-release gates passed (image-scan strict, cve-check advisory)."
+
 #release: @ Create a release tag with semver validation (usage: make release VERSION=x.y.z)
-release:
+#          Runs `pre-release` first so a failing OWASP or image scan blocks the
+#          tag before any ref is written. This is the only reliable local
+#          checkpoint for Paketo-layer CVEs (they're not in `make ci`).
+release: pre-release
 	@if [ -z "$(VERSION)" ]; then \
 		echo "Error: VERSION is required. Usage: make release VERSION=x.y.z"; \
 		exit 1; \
@@ -561,5 +574,5 @@ release:
 	ci ci-run cve-check coverage-generate coverage-check coverage-open \
 	print-deps-updates update-deps renovate-validate \
 	image-build image-scan mirror-images kind-create kind-deploy kind-undeploy kind-destroy \
-	kind-up kind-down e2e release \
+	kind-up kind-down e2e pre-release release \
 	diagrams diagrams-clean diagrams-check mermaid-lint


### PR DESCRIPTION
## Summary
- New `make pre-release` composite runs every slow gate missing from `make ci`: `cve-check` (advisory, mirrors CI's `continue-on-error: true` while the upstream OWASP NVD deserializer bug is unpatched) + `image-scan` (strict).
- `make release` now hard-depends on `pre-release`, so a tag can't be written locally without the Paketo image scan passing.
- `.trivyignore` accepts the three Go-stdlib CVEs baked into Paketo lifecycle helpers (`paketo-buildpacks_ca-certificates/helper`, `paketo-buildpacks_spring-boot/helper`) — fix is upstream-only (Paketo rebuild on Go 1.26.2+). Entries include CVE ID + reason + upstream tracker + removal policy.
- `.gitignore`: ignore Claude Code transient state (`scheduled_tasks.lock`, `settings.local.json`).
- `CLAUDE.md` Build & Test Commands + Upgrade Backlog updated.

## Root cause
First `v0.1.0` tag push failed in CI when Trivy found 3 HIGH Go-stdlib CVEs in Paketo lifecycle helper binaries that no local gate ever ran against. `make ci` and `make ci-run` do not exercise `image-scan` — it lives downstream of `kind-deploy`/`e2e`. The scan only ran for the first time in live CI on tag push, which is the latest possible moment.

## Test plan
- [x] `make ci-run` (act) — all four jobs green locally before push
- [ ] PR CI (this run): static-check, build, test, integration-test, e2e all green
- [ ] e2e's `image-scan` step passes with `.trivyignore` active (verifies the three CVE IDs are correctly suppressed and any new CVE would still fail)
- [ ] After merge, re-tag `v0.1.0` from fresh main; `publish-images` job runs and pushes to GHCR.

Fixes the v0.1.0 publish failure from https://github.com/AndriyKalashnykov/dapr-java/actions/runs/24679395087.