### PR TITLE
ci: auto-gate e2e via paths-filter, keep run-e2e label as escape hatch

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -55,6 +55,33 @@ env:
   MAVEN_OPTS: '-Xmx1024m'
 
 jobs:
+  # Inspect the PR diff and expose which path groups changed. Downstream jobs
+  # that are expensive to always-run (e2e) can gate on these outputs so they
+  # only execute when relevant code changed, while docs-only / renovate PRs
+  # skip them. The `run-e2e` label remains a manual escape hatch for the rare
+  # "force-run e2e on a docs change" case.
+  changes:
+    runs-on: ubuntu-latest
+    timeout-minutes: 2
+    outputs:
+      e2e: ${{ steps.filter.outputs.e2e }}
+    steps:
+    - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+    - uses: dorny/paths-filter@fbd0ab8f3e69293af611ebaee6363fc25e6d187d # v4.0.1
+      id: filter
+      with:
+        filters: |
+          e2e:
+            - 'k8s/**'
+            - 'k8s-dapr-shared/**'
+            - 'pom.xml'
+            - 'pizza-*/pom.xml'
+            - 'pizza-*/src/**'
+            - 'Makefile'
+            - '.github/workflows/ci.yml'
+            - 'e2e/**'
+            - 'scripts/**'
+
   static-check:
     runs-on: ubuntu-latest
     timeout-minutes: 10
@@ -255,10 +282,10 @@ jobs:
   # we keep it off every PR by default and rely on static-check/build/test
   # to catch most bugs early.
   e2e:
-    needs: [build, test, integration-test]
+    needs: [build, test, integration-test, changes]
     if: |
       (github.event_name == 'push' && (github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/tags/'))) ||
-      (github.event_name == 'pull_request' && contains(github.event.pull_request.labels.*.name, 'run-e2e')) ||
+      (github.event_name == 'pull_request' && (contains(github.event.pull_request.labels.*.name, 'run-e2e') || needs.changes.outputs.e2e == 'true')) ||
       github.event_name == 'workflow_dispatch'
     runs-on: ubuntu-latest
     timeout-minutes: 20
@@ -369,7 +396,7 @@ jobs:
 
   ci-pass:
     if: always()
-    needs: [static-check, build, test, integration-test, cve-check, e2e, publish-images]
+    needs: [changes, static-check, build, test, integration-test, cve-check, e2e, publish-images]
     timeout-minutes: 2
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
## Summary
Replaces the pure label-based e2e gate with a path-based one. Fixes the label-ceremony pain surfaced 4x during the v0.1.x publish work (label didn't exist → had to create via `gh label create`; adding label to open PR didn't retrigger the workflow → had to close+reopen PR).

New job `changes` at stage 0 runs `dorny/paths-filter@v4.0.1` on the PR diff and exposes an `e2e` boolean. The e2e job's `if:` runs when EITHER the `run-e2e` label is present (manual opt-in, preserved) OR the diff touched e2e-relevant paths (k8s/, pom.xml, pizza-*/pom.xml, pizza-*/src/**, Makefile, ci.yml, e2e/, scripts/).

Portfolio-portable: each project declares its own path set in this single job. Avoids GitHub's limitation that `on.pull_request.paths` applies to the whole workflow, not per-job.

## Changes
- `.github/workflows/ci.yml` — new `changes` job, updated `e2e` `if:` + `needs:`, added `changes` to `ci-pass` needs.

## Test plan
- [x] `act --list` parses cleanly (new DAG stages visible)
- [ ] This PR itself touches ci.yml — the path filter SHOULD classify it as e2e-relevant, so e2e should auto-run on this PR without any label
- [ ] After merge, a docs-only PR should skip e2e; a pom.xml bump from Renovate should auto-run e2e