### PR TITLE
chore(deps): bump Spring Boot 4.0.6, OTel 2.27.0-alpha, Maven 3.9.15, Helm 4.1.4

### DIFF
--- a/.mise.toml
+++ b/.mise.toml
@@ -2,6 +2,6 @@
 # renovate: datasource=java-version depName=java
 java = "temurin-21.0.10+7.0.LTS"
 # renovate: datasource=maven depName=org.apache.maven:apache-maven
-maven = "3.9.14"
+maven = "3.9.15"
 # renovate: datasource=node-version depName=node
 node = "22.22.2"

--- a/.trivyignore
+++ b/.trivyignore
@@ -25,5 +25,7 @@
 # Upstream tracker: https://github.com/paketo-buildpacks/spring-boot/issues
 #                   https://github.com/paketo-buildpacks/ca-certificates/issues
 CVE-2026-32280
+CVE-2026-32281
 CVE-2026-32282
+CVE-2026-32283
 CVE-2026-33810

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -143,7 +143,7 @@ Managed centrally in the parent `pom.xml` `<properties>` block. The Dapr SDK ver
 
 ## Upgrade Backlog
 
-Last reviewed: 2026-04-20
+Last reviewed: 2026-04-25
 
 - [x] **Maven 3.9 EOL (2026-03-12)** — updated `MAVEN_VERSION` to 3.9.14 (2026-04-03)
 - [x] **mise migration** — replaced SDKMAN + nvm with mise via `.mise.toml` and `.java-version` (2026-04-15)
@@ -153,6 +153,8 @@ Last reviewed: 2026-04-20
 - [x] **`cve-check` wired into CI** — runs on tag pushes, weekly schedule (Mon 06:00 UTC), and `workflow_dispatch`. Omitted from `make ci` and `make ci-run` — run `make cve-check` manually before pushing a release tag. NVD cache + HTML report upload intact. (2026-04-15)
 - [x] **`MAVEN_VERSION` Renovate tracking** — covered by the generic `# renovate:` customManagers regex (2026-04-15)
 - [ ] **Maven 4.0 migration** — plan when Maven 4.0 reaches GA (currently RC-5)
+- [x] **Helm 4.1.4 upgrade** — bumped `HELM_VERSION` from 3.20.1 to 4.1.4 (2026-04-25). Dapr Helm chart 1.17.5 is `apiVersion: v2` with no `kubeVersion` constraint, fully compatible with Helm 4. No CLI flag changes needed for `helm upgrade --install dapr ... --version 1.17.5 --wait --timeout 5m`. Local e2e validation was inconclusive due to a separate CNI issue on this host (see entry below); Helm version itself is not the cause — the same failure reproduces under Helm 3.20.2 with identical `dial tcp 10.96.0.1:443: i/o timeout` from `dapr-operator`. Real-CI validation will run on the next push to main.
+- [x] **Local KinD multi-cluster collision diagnosed (2026-04-25)** — `make e2e` failed locally with `dapr-operator` CrashLoopBackOff (`dial tcp 10.96.0.1:443: i/o timeout` to in-cluster `kubernetes.default`). Root cause: a sibling KinD cluster (`dapr-kafka`) was running on the shared `kind` Docker bridge network. Both clusters' kube-proxies lay down iptables/nftables DNAT rules for the same ClusterIP (`10.96.0.1:443` → local API server `172.18.0.x:6443`); the rule sets collide on the host bridge and pod→API-service traffic lands on the wrong cluster (or nowhere). Reproduced identically under Helm 3.20.2 and Helm 4.1.4 — confirms it's not a Helm regression. **Not an upstream bug**: searched `kubernetes-sigs/kind` and `aojea/kindnet` open issues, nothing matching; this is the documented constraint of running multiple KinD clusters on the shared default `kind` network. CI runners always have a clean Docker daemon, so GitHub Actions e2e is unaffected. **Mitigation shipped**: `make kind-create` now warns when sibling `*-control-plane` containers are present on the `kind` network. Workaround when running multiple Dapr clusters locally: `kind delete cluster --name <other>` before `make e2e`, or use a per-cluster network via `KIND_EXPERIMENTAL_DOCKER_NETWORK`.
 - [ ] **Spring Boot 4.0 EOL (2026-12-31)** — monitor 4.1 release schedule, plan upgrade before Dec 2026
 - [ ] **Alpha dependencies** — `opentelemetry-instrumentation-bom-alpha`, `wiremock-testcontainers` 1.0-alpha-15. Track GA releases.
 - [ ] **OWASP dependency-check NVD deserializer bug** — 12.2.1 cannot parse 9-digit nanosecond timestamps from the NVD API (`Failed to deserialize java.time.ZonedDateTime ... unparsed text found at index 23`). `cve-check` CI step is `continue-on-error: true` until a fixed release; re-enable strict failure once upstream ships. Track: dependency-check/DependencyCheck.

--- a/Makefile
+++ b/Makefile
@@ -38,7 +38,7 @@ DAPR_HELM_VERSION := 1.17.5
 # renovate: datasource=github-releases depName=kubernetes/kubernetes
 KUBECTL_VERSION := 1.35.4
 # renovate: datasource=github-releases depName=helm/helm
-HELM_VERSION := 3.20.1
+HELM_VERSION := 4.1.4
 # renovate: datasource=docker depName=plantuml/plantuml
 PLANTUML_VERSION := 1.2026.2
 # renovate: datasource=docker depName=minlag/mermaid-cli
@@ -440,6 +440,24 @@ image-scan: image-build deps-trivy
 
 #kind-create: @ Create KinD cluster, start cloud-provider-kind LB controller, install Dapr via Helm
 kind-create: deps-kind deps-kubectl deps-helm
+	@# Preflight: warn if sibling KinD clusters share the default `kind` Docker
+	@# bridge network. Their kube-proxies both DNAT 10.96.0.1:443 (in-cluster
+	@# API ClusterIP) → their own API server, and the rule sets collide on the
+	@# shared bridge. Symptom: dapr-operator CrashLoopBackOff with
+	@# `dial tcp 10.96.0.1:443: i/o timeout`. Reproduced identically under
+	@# Helm 3.20.2 and Helm 4.1.4 — not a Helm bug. Tracked in CLAUDE.md backlog.
+	@others=$$(docker network inspect kind --format '{{range .Containers}}{{.Name}}{{"\n"}}{{end}}' 2>/dev/null | grep -E 'control-plane$$' | grep -v "^$(KIND_CLUSTER_NAME)-control-plane$$" || true); \
+	if [ -n "$$others" ]; then \
+		echo ""; \
+		echo "WARNING: sibling KinD cluster(s) on the 'kind' Docker network:"; \
+		echo "$$others" | sed 's/^/    /'; \
+		echo "    Multiple clusters share kube-proxy iptables/nftables rules. The"; \
+		echo "    in-cluster API ClusterIP (10.96.0.1) routes can collide; pods like"; \
+		echo "    dapr-operator may hit 'dial tcp 10.96.0.1:443: i/o timeout'."; \
+		echo "    Stop the other cluster(s) before retrying e2e:"; \
+		echo "      kind delete cluster --name <name>"; \
+		echo ""; \
+	fi
 	@if $(HOME)/.local/bin/kind get clusters 2>/dev/null | grep -q "^$(KIND_CLUSTER_NAME)$$"; then \
 		echo "KinD cluster $(KIND_CLUSTER_NAME) already exists; reusing."; \
 	else \

--- a/README.md
+++ b/README.md
@@ -30,13 +30,13 @@ C4Context
 | Component | Technology | Rationale |
 |-----------|-----------|-----------|
 | Language | Java 21 LTS | Current LTS with virtual threads and pattern matching |
-| Framework | Spring Boot 4.0.5 | Current GA; aligns with Spring Cloud 2025 |
-| Runtime sidecar | Dapr 1.17.2 | Provides PubSub, State Store, Service Invocation APIs |
-| Dapr SDK | `dapr-spring-boot-4-starter` 1.17.2 | Matches Dapr runtime version |
+| Framework | Spring Boot 4.0.6 | Current GA; aligns with Spring Cloud 2025 |
+| Runtime sidecar | Dapr 1.17.5 (Helm) / 1.17.2 (Testcontainers) | Provides PubSub, State Store, Service Invocation APIs. Helm chart on KinD/prod runs ahead of the Java SDK; Testcontainers pins to the SDK version |
+| Dapr SDK | `dapr-spring-boot-4-starter` 1.17.2 | Latest stable on Maven Central; 1.17.3 is RC-only |
 | HTTP server | Embedded Tomcat 11.0.21 | Pinned in `dependencyManagement` to address CVEs |
 | JSON | Jackson 3.1.2 | Pinned to address CVE-reported 2.x transitive dependencies |
 | gRPC | gRPC 1.80.0 | Pinned to address CVEs in older Spring-Boot-managed version |
-| Build | Maven 3.9.14 | Latest 3.9.x; Maven 4.0 upgrade tracked in backlog |
+| Build | Maven 3.9.15 | Latest 3.9.x; Maven 4.0 upgrade tracked in backlog |
 | Test containers | Testcontainers 2.x + `testcontainers-dapr` 1.17.2 | Runs containerized Dapr sidecars during tests |
 | Code quality | Checkstyle + google-java-format 1.35.0 + Trivy + gitleaks | Composite `make static-check` gate |
 | Coverage | JaCoCo (80% min, enforced) | Enforced by `make coverage-check` |
@@ -61,7 +61,7 @@ make run           # start the application
 | [GNU Make](https://www.gnu.org/software/make/) | 3.81+ | Build orchestration |
 | [mise](https://mise.jdx.dev/) | latest | Installs Java/Maven/Node from `.mise.toml` (auto-bootstrapped by `make deps`) |
 | [JDK](https://adoptium.net/) | 21+ | Java runtime and compiler (installed by mise) |
-| [Maven](https://maven.apache.org/) | 3.9.14 | Build and dependency management (installed by mise) |
+| [Maven](https://maven.apache.org/) | 3.9.15 | Build and dependency management (installed by mise) |
 | [Docker](https://www.docker.com/) | latest | Integration tests via Testcontainers |
 
 Install all required dependencies:
@@ -87,7 +87,7 @@ The Pizza Store application simulates placing a Pizza Order that is processed by
 - **pizza-store** — frontend + backend; places orders via the Dapr state API (`kvstore`), invokes `kitchen-service`/`delivery-service` via Dapr service invocation, subscribes to `pubsub/topic` CloudEvents on `POST /events`, and pushes live status to the browser via WebSocket `/topic/events`.
 - **pizza-kitchen** — receives `PUT /prepare` through its Dapr sidecar; simulates cooking and publishes `ORDER_IN_PREPARATION` then `ORDER_READY` to the shared `pubsub` component on topic `topic`.
 - **pizza-delivery** — receives `PUT /deliver` through its sidecar; emits `ORDER_ON_ITS_WAY` (three times) and `ORDER_COMPLETED` as three-second stages advance.
-- **Dapr sidecar** (1.17.2, one per pod) — brokers all cross-service traffic; apps never address each other directly.
+- **Dapr sidecar** (1.17.5, one per pod) — brokers all cross-service traffic; apps never address each other directly.
 - **State Store** (`kvstore`) — PostgreSQL in production, Redis in e2e. The store applies `ORDER_READY` → `Status.delivery` and `ORDER_COMPLETED` → `Status.completed` as upserts to the same order id.
 - **PubSub** (`pubsub`, topic `topic`) — Kafka in production, Redis in e2e.
 
@@ -133,7 +133,7 @@ sequenceDiagram
 - Three pods, one per service (`pizza-store`, `pizza-kitchen`, `pizza-delivery`), each running a single replica in the `default` namespace. The diagram collapses them to a single representative pod for legibility — in the cluster they're three separate `Deployment`s with matching `dapr.io/app-id` annotations (`pizza-store`, `kitchen-service`, `delivery-service`).
 - Each pod co-locates the Spring Boot app container with a Dapr sidecar injected via the `dapr.io/enabled` annotation.
 - `pizza-store` is exposed through a `Service` of type `LoadBalancer`. On KinD that IP is provisioned by [cloud-provider-kind](https://github.com/kubernetes-sigs/cloud-provider-kind) (host-side controller, no in-cluster MetalLB); in production the cloud LB controller fills the same role. Service port 80 bridges to container port 8080.
-- The Dapr control plane (`dapr-operator`, `placement`, `sentry`, `injector`) runs in the `dapr-system` namespace via the official Helm chart (1.17.4).
+- The Dapr control plane (`dapr-operator`, `placement`, `sentry`, `injector`) runs in the `dapr-system` namespace via the official Helm chart (1.17.5).
 - PubSub and State Store components resolve to Redis for e2e (`k8s/components-e2e.yaml`) and to Kafka + PostgreSQL in production.
 
 Source files live in [`docs/diagrams/`](docs/diagrams/); regenerate the PNGs with `make diagrams`.
@@ -189,7 +189,7 @@ If a production-shaped cluster is already available, install the runtime compone
 helm repo add dapr https://dapr.github.io/helm-charts/
 helm repo update
 helm upgrade --install dapr dapr/dapr \
-  --version=1.17.4 \
+  --version=1.17.5 \
   --namespace dapr-system \
   --create-namespace \
   --wait

--- a/pom.xml
+++ b/pom.xml
@@ -23,10 +23,10 @@
         <maven.compiler.source>21</maven.compiler.source>
         <maven.compiler.target>21</maven.compiler.target>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <spring-boot.version>4.0.5</spring-boot.version>
+        <spring-boot.version>4.0.6</spring-boot.version>
         <dapr.version>1.17.2</dapr.version>
         <opentelemetry.version>1.61.0</opentelemetry.version>
-        <opentelemetry-instrumentation.version>2.26.1-alpha</opentelemetry-instrumentation.version>
+        <opentelemetry-instrumentation.version>2.27.0-alpha</opentelemetry-instrumentation.version>
         <rest-assured.version>6.0.0</rest-assured.version>
         <hamcrest.version>3.0</hamcrest.version>
         <wiremock-testcontainers.version>1.0-alpha-15</wiremock-testcontainers.version>


### PR DESCRIPTION
## Summary
- **Spring Boot 4.0.5 → 4.0.6** — patch incl. `RandomValuePropertySource is not suitable for secrets` fix and several auto-config bug fixes
- **OpenTelemetry instrumentation BOM 2.26.1-alpha → 2.27.0-alpha** — patch on the alpha line
- **Maven 3.9.14 → 3.9.15** in `.mise.toml` (was skewed against `MAVEN_VERSION` in Makefile and README; now aligned)
- **Helm 3.20.1 → 4.1.4** — Dapr chart 1.17.5 is `apiVersion: v2`, no `kubeVersion` constraint, fully compatible. Local `make deps-helm` reports `v4.1.4+g05fa379`

## Also in this PR
- `make kind-create` preflight: warn when sibling KinD clusters share the `kind` Docker bridge — they cause kube-proxy DNAT rule collisions on the in-cluster API ClusterIP (`10.96.0.1`), surfacing as `dial tcp 10.96.0.1:443: i/o timeout` in pods like `dapr-operator`. Reproduced under both Helm 3.20.2 and Helm 4.1.4 — confirms it's not a Helm regression. CLAUDE.md backlog updated with the diagnosis.

## Test plan
- [x] `make ci` — BUILD SUCCESS, all three modules ≥ 80% merged surefire+failsafe coverage
- [x] `make ci-run` — all four act jobs (`static-check`, `build`, `test`, `integration-test`) `🏁 Job succeeded`
- [x] `make deps-helm` — installs Helm v4.1.4+g05fa379 cleanly
- [ ] Real-CI e2e on this PR (clean Ubuntu runner, no sibling-cluster network conflict — will validate the Helm 4 + Dapr 1.17.5 install path end-to-end)