### PR TITLE
chore: project-review fixes + image hardening + test-coverage cleanup

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,35 +4,8 @@ on:
   push:
     branches: [main]
     tags: ['v*']
-    paths-ignore:
-      - '*.md'
-      - '!CLAUDE.md'
-      - 'docs/**'
-      - 'specs/**'
-      - 'LICENSE'
-      - '.gitignore'
-      - '.claudeignore'
-      - '.claude/**'
-      - 'benchmarks/**'
-      - '**.png'
-      - '**.jpg'
-      - '**.gif'
-      - '**.svg'
   pull_request:
-    paths-ignore:
-      - '*.md'
-      - '!CLAUDE.md'
-      - 'docs/**'
-      - 'specs/**'
-      - 'LICENSE'
-      - '.gitignore'
-      - '.claudeignore'
-      - '.claude/**'
-      - 'benchmarks/**'
-      - '**.png'
-      - '**.jpg'
-      - '**.gif'
-      - '**.svg'
+    branches: [main]
   workflow_call:
   # Weekly OWASP/NVD scan so new upstream advisories are caught even without
   # a code push. Monday 06:00 UTC keeps the cve-check job off the critical
@@ -47,6 +20,10 @@ concurrency:
 
 permissions:
   contents: read
+  # pull-requests: read is required for dorny/paths-filter on pull_request
+  # events — without it, listFiles() fails with "Resource not accessible by
+  # integration" and the changes job blocks every gated downstream job.
+  pull-requests: read
   # packages: write is elevated only on the publish-images job (tags only).
   # Keeping the workflow-default at read minimizes blast radius on every
   # main/PR run.
@@ -56,21 +33,28 @@ env:
 
 jobs:
   # Inspect the PR diff and expose which path groups changed. Downstream jobs
-  # that are expensive to always-run (e2e) can gate on these outputs so they
-  # only execute when relevant code changed, while docs-only / renovate PRs
-  # skip them. The `run-e2e` label remains a manual escape hatch for the rare
-  # "force-run e2e on a docs change" case.
+  # gate on `code` (binary skip-everything-on-docs-only) and `e2e` (the
+  # heavy KinD job, off by default on PRs unless code under k8s/ / Java
+  # sources / Makefile / workflow itself changed). The `run-e2e` label
+  # remains a manual escape hatch for the rare "force-run e2e on a docs
+  # change" case.
   changes:
     runs-on: ubuntu-latest
     timeout-minutes: 2
     outputs:
+      code: ${{ steps.filter.outputs.code }}
       e2e: ${{ steps.filter.outputs.e2e }}
     steps:
-    - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
-    - uses: dorny/paths-filter@fbd0ab8f3e69293af611ebaee6363fc25e6d187d # v4.0.1
+    - name: Checkout
+      uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+    - name: Detect changed paths
+      uses: dorny/paths-filter@fbd0ab8f3e69293af611ebaee6363fc25e6d187d # v4.0.1
       id: filter
       with:
         filters: |
+          code:
+            - '!(**.md|docs/**|specs/**|LICENSE|.gitignore|.claudeignore|.claude/**|benchmarks/**|**.png|**.jpg|**.gif|**.svg)'
+            - 'CLAUDE.md'
           e2e:
             - 'k8s/**'
             - 'k8s-dapr-shared/**'
@@ -83,6 +67,8 @@ jobs:
             - 'scripts/**'
 
   static-check:
+    needs: [changes]
+    if: needs.changes.outputs.code == 'true'
     runs-on: ubuntu-latest
     timeout-minutes: 10
 
@@ -93,7 +79,8 @@ jobs:
       with:
         fetch-depth: 0
 
-    - uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 # v5
+    - name: Set up JDK
+      uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 # v5
       with:
         java-version-file: '.java-version'
         distribution: 'temurin'
@@ -102,11 +89,20 @@ jobs:
     - name: Ensure Maven is installed
       run: make deps-maven
 
+    # static-check invokes trivy + gitleaks (in addition to format-check,
+    # checkstyle, diagrams-check, mermaid-lint). mise installs both pinned
+    # to .mise.toml; the act runner image has neither preinstalled.
+    - name: Install mise (provides trivy, gitleaks pinned)
+      uses: jdx/mise-action@1648a7812b9aeae629881980618f079932869151 # v4.0.1
+      with:
+        cache: true
+
     - name: Static check
       run: make static-check
 
   build:
-    needs: [static-check]
+    needs: [changes, static-check]
+    if: needs.changes.outputs.code == 'true'
     runs-on: ubuntu-latest
     timeout-minutes: 15
 
@@ -115,7 +111,8 @@ jobs:
     - name: Checkout
       uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
-    - uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 # v5
+    - name: Set up JDK
+      uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 # v5
       with:
         java-version-file: '.java-version'
         distribution: 'temurin'
@@ -146,7 +143,8 @@ jobs:
   # Unit tests only — fast feedback loop. Runs surefire (no Testcontainers
   # heavy lifting, no Dapr sidecars). Integration tests live in their own job.
   test:
-    needs: [static-check]
+    needs: [changes, static-check]
+    if: needs.changes.outputs.code == 'true'
     runs-on: ubuntu-latest
     timeout-minutes: 10
 
@@ -155,7 +153,8 @@ jobs:
     - name: Checkout
       uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
-    - uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 # v5
+    - name: Set up JDK
+      uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 # v5
       with:
         java-version-file: '.java-version'
         distribution: 'temurin'
@@ -173,7 +172,8 @@ jobs:
   # Also produces the merged unit+IT JaCoCo coverage report and gates on the
   # 0.80 portfolio threshold.
   integration-test:
-    needs: [static-check]
+    needs: [changes, static-check]
+    if: needs.changes.outputs.code == 'true'
     runs-on: ubuntu-latest
     timeout-minutes: 20
 
@@ -182,7 +182,8 @@ jobs:
     - name: Checkout
       uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
-    - uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 # v5
+    - name: Set up JDK
+      uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 # v5
       with:
         java-version-file: '.java-version'
         distribution: 'temurin'
@@ -196,7 +197,6 @@ jobs:
 
     - name: Verify coverage threshold
       run: make coverage-check
-      continue-on-error: true
 
     - name: Upload coverage report
       if: always()
@@ -208,7 +208,7 @@ jobs:
         retention-days: 14
 
   cve-check:
-    needs: [build, test, integration-test]
+    needs: [static-check]
     # Gated to cut CI cost on every main push. Runs on:
     #   - tag pushes (release-time gate before shipping)
     #   - weekly schedule (catches new upstream CVEs in unchanged deps)
@@ -228,7 +228,8 @@ jobs:
     - name: Checkout
       uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
-    - uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 # v5
+    - name: Set up JDK
+      uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 # v5
       with:
         java-version-file: '.java-version'
         distribution: 'temurin'
@@ -270,19 +271,20 @@ jobs:
         if-no-files-found: ignore
 
   # MANDATORY end-to-end test job. Deploys the three services plus Dapr to
-  # a KinD cluster (MetalLB + in-memory pubsub/state store) and runs
-  # e2e/e2e-test.sh through the MetalLB-exposed pizza-store LoadBalancer.
+  # a KinD cluster (cloud-provider-kind LB + redis-backed pubsub/state) and
+  # runs e2e/e2e-test.sh through the LoadBalancer-exposed pizza-store.
   #
   # Trigger policy:
   #   - Every push to main and every tag push (baseline coverage)
   #   - Pull requests labelled `run-e2e` (opt-in for feature branches)
+  #   - Pull requests where changes.e2e=='true' (e2e-relevant paths)
   #   - Manual runs via workflow_dispatch
   #
   # KinD + image-build + Dapr install runs ~10-15 min on GitHub runners, so
   # we keep it off every PR by default and rely on static-check/build/test
   # to catch most bugs early.
   e2e:
-    needs: [build, test, integration-test, changes]
+    needs: [changes, build, test]
     if: |
       (github.event_name == 'push' && (github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/tags/'))) ||
       (github.event_name == 'pull_request' && (contains(github.event.pull_request.labels.*.name, 'run-e2e') || needs.changes.outputs.e2e == 'true')) ||
@@ -294,7 +296,8 @@ jobs:
     - name: Checkout
       uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
-    - uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 # v5
+    - name: Set up JDK
+      uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 # v5
       with:
         java-version-file: '.java-version'
         distribution: 'temurin'
@@ -303,8 +306,10 @@ jobs:
     - name: Ensure Maven is installed
       run: make deps-maven
 
-    - name: Install kind, kubectl, helm (pinned)
-      run: make deps-kind deps-kubectl deps-helm
+    - name: Install mise (provides kind, kubectl, helm, trivy, gitleaks pinned)
+      uses: jdx/mise-action@1648a7812b9aeae629881980618f079932869151 # v4.0.1
+      with:
+        cache: true
 
     - name: Run end-to-end tests
       run: make e2e
@@ -328,19 +333,37 @@ jobs:
         path: /tmp/e2e-diag/
         retention-days: 7
 
-  # First-party OCI image publish. Triggers only on v* tag pushes and only
-  # after every validation job is green. Images are built via Paketo (same
-  # spring-boot:build-image path as `make image-build`), scanned by
-  # `make image-scan`, then retagged and pushed to ghcr.io under this
-  # repository's owner.
+  # First-party OCI image publish with pre-push hardening gates. Triggers
+  # only on v* tag pushes and only after every validation job is green.
+  # Per /harden-image-pipeline canonical pattern (Pattern A — Phase 1+2):
+  #   GATE 1: Trivy image scan (CRITICAL/HIGH blocking, fixed-only).
+  #   GATE 2: Spring Boot boot-marker smoke test (catches boot regressions
+  #           Trivy can't see — missing classes, port binds, config errors).
+  #   GATE 3: cosign keyless OIDC signing post-push (Sigstore Fulcio).
+  # provenance: false / sbom: false: not applicable to Paketo CNB build path
+  # (no buildkit attestations emitted), so the GHCR Packages "OS / Arch" tab
+  # already renders correctly.
+  # Multi-arch is single-arch (linux/amd64) for now — Paketo CNB
+  # spring-boot:build-image runs only on the host's native arch. ARM
+  # consumers (Apple Silicon, Graviton) need either a runs-on:
+  # ubuntu-24.04-arm matrix runner + manifest assemble, or a thin Dockerfile
+  # + docker/build-push-action. Tracked in CLAUDE.md upgrade backlog.
+  # strategy.matrix runs each service in parallel on its own runner —
+  # wall-clock = max(per-service-time), not sum.
   publish-images:
-    needs: [static-check, build, test, integration-test, e2e]
+    needs: [static-check, build, test, integration-test, cve-check, e2e]
     if: startsWith(github.ref, 'refs/tags/v')
     runs-on: ubuntu-latest
     timeout-minutes: 30
     permissions:
       contents: read
       packages: write
+      id-token: write       # cosign keyless OIDC (Sigstore Fulcio)
+    strategy:
+      fail-fast: false      # one bad service shouldn't cancel the others'
+                            # in-flight scans/signs — collect all results
+      matrix:
+        service: [pizza-store, pizza-kitchen, pizza-delivery]
     env:
       REGISTRY: ghcr.io
 
@@ -348,7 +371,8 @@ jobs:
     - name: Checkout
       uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
-    - uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 # v5
+    - name: Set up JDK
+      uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 # v5
       with:
         java-version-file: '.java-version'
         distribution: 'temurin'
@@ -357,42 +381,116 @@ jobs:
     - name: Ensure Maven is installed
       run: make deps-maven
 
+    - name: Install mise (provides trivy pinned)
+      uses: jdx/mise-action@1648a7812b9aeae629881980618f079932869151 # v4.0.1
+      with:
+        cache: true
+
     - name: Derive version from tag
       id: ver
       run: echo "version=${GITHUB_REF_NAME#v}" >> "$GITHUB_OUTPUT"
 
-    - name: Build + scan images
-      run: make image-scan
+    - name: Lowercase namespace
+      id: ns
+      run: |
+        OWNER=$(echo "${{ github.repository_owner }}" | tr '[:upper:]' '[:lower:]')
+        REPO=$(echo "${{ github.event.repository.name }}" | tr '[:upper:]' '[:lower:]')
+        echo "owner=${OWNER}" >> "$GITHUB_OUTPUT"
+        echo "repo=${REPO}" >> "$GITHUB_OUTPUT"
+
+    # GATE 1+2: Build + Trivy image scan via existing make target.
+    # SERVICES override scopes the loop to this matrix entry only — each
+    # service builds + scans on its own runner in parallel.
+    - name: Build + scan ${{ matrix.service }} image
+      run: make image-scan SERVICES='${{ matrix.service }}'
+
+    # GATE 3: Spring Boot boot-marker smoke test.
+    # Validates the image actually boots Spring Boot before publishing —
+    # catches regressions Trivy and filesystem scans miss (missing classes,
+    # port bind failures, broken auto-config). Pizza services depend on
+    # Dapr sidecars + state store at runtime, so the readiness probe would
+    # fail without them; the boot-marker fires BEFORE any external-dep
+    # check, which is exactly what we want here.
+    - name: Smoke test ${{ matrix.service }}
+      run: |
+        set -euo pipefail
+        SVC='${{ matrix.service }}'
+        docker run -d --name="${SVC}-smoke" "${SVC}:e2e"
+        echo "Waiting up to 90s for Spring Boot to boot..."
+        end=$((SECONDS + 90))
+        while [ $SECONDS -lt $end ]; do
+          if docker logs "${SVC}-smoke" 2>&1 | grep -qE 'Started [A-Z][a-zA-Z]+Application in|Tomcat started on port|Netty started on port'; then
+            echo "PASS: ${SVC} container booted Spring Boot successfully"
+            docker rm -f "${SVC}-smoke" >/dev/null
+            exit 0
+          fi
+          sleep 3
+        done
+        echo "FAIL: ${SVC} did not reach Spring Boot start within 90s"
+        docker logs "${SVC}-smoke"
+        docker rm -f "${SVC}-smoke" >/dev/null || true
+        exit 1
+
+    - name: Cleanup smoke container
+      if: always()
+      run: docker rm -f '${{ matrix.service }}-smoke' 2>/dev/null || true
 
     - name: Log in to GHCR
       # renovate: datasource=github-releases depName=docker/login-action
-      uses: docker/login-action@74a5d142397b4f367a81961eba4e8cd7edddf772 # v3.4.0
+      uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121 # v4.1.0
       with:
         registry: ${{ env.REGISTRY }}
         username: ${{ github.actor }}
         password: ${{ secrets.GITHUB_TOKEN }}
 
-    - name: Tag + push to GHCR
+    - name: Tag + push ${{ matrix.service }} to GHCR
+      id: push
       env:
+        SVC: ${{ matrix.service }}
         VERSION: ${{ steps.ver.outputs.version }}
+        OWNER: ${{ steps.ns.outputs.owner }}
+        REPO: ${{ steps.ns.outputs.repo }}
       run: |
+        set -euo pipefail
         # Use repo-namespace (ghcr.io/<owner>/<repo>/<package>) rather than
         # user-namespace (ghcr.io/<owner>/<package>). GITHUB_TOKEN can CREATE
         # new packages in the repo-namespace — GHCR auto-links them to this
         # repo. In the user-namespace it cannot, resulting in
         # `denied: permission_denied: write_package` on first push.
-        OWNER=$(echo "${{ github.repository_owner }}" | tr '[:upper:]' '[:lower:]')
-        REPO=$(echo "${{ github.event.repository.name }}" | tr '[:upper:]' '[:lower:]')
-        for svc in pizza-store pizza-kitchen pizza-delivery; do
-          src="${svc}:e2e"
-          dst_ver="${REGISTRY}/${OWNER}/${REPO}/${svc}:${VERSION}"
-          dst_latest="${REGISTRY}/${OWNER}/${REPO}/${svc}:latest"
-          echo "--- ${src} → ${dst_ver} + ${dst_latest} ---"
-          docker tag "${src}" "${dst_ver}"
-          docker tag "${src}" "${dst_latest}"
-          docker push "${dst_ver}"
-          docker push "${dst_latest}"
-        done
+        src="${SVC}:e2e"
+        dst_ver="${REGISTRY}/${OWNER}/${REPO}/${SVC}:${VERSION}"
+        dst_latest="${REGISTRY}/${OWNER}/${REPO}/${SVC}:latest"
+        echo "--- ${src} → ${dst_ver} + ${dst_latest} ---"
+        docker tag "${src}" "${dst_ver}"
+        docker tag "${src}" "${dst_latest}"
+        docker push "${dst_ver}"
+        docker push "${dst_latest}"
+        # Capture the manifest digest so cosign signs by digest, not by tag —
+        # the digest covers all tags pointing to it and produces a clearer
+        # Rekor trail than tag-based signing.
+        DIGEST=$(docker inspect --format '{{ index .RepoDigests 0 }}' "${dst_ver}" | sed 's/.*@//')
+        echo "digest=${DIGEST}" >> "$GITHUB_OUTPUT"
+        {
+          echo 'tags<<TAGS_EOF'
+          echo "${dst_ver}"
+          echo "${dst_latest}"
+          echo 'TAGS_EOF'
+        } >> "$GITHUB_OUTPUT"
+
+    - name: Install cosign
+      uses: sigstore/cosign-installer@cad07c2e89fa2edd6e2d7bab4c1aa38e53f76003 # v4.1.1
+
+    - name: Sign image with cosign (keyless OIDC)
+      env:
+        TAGS: ${{ steps.push.outputs.tags }}
+        DIGEST: ${{ steps.push.outputs.digest }}
+      run: |
+        set -euo pipefail
+        while IFS= read -r tag; do
+          [ -z "$tag" ] && continue
+          echo "→ cosign sign ${tag}@${DIGEST}"
+          cosign sign --yes "${tag}@${DIGEST}"
+        done <<< "${TAGS}"
 
   ci-pass:
     if: always()
@@ -403,8 +501,14 @@ jobs:
       - name: Verify all required jobs passed
         run: |
           # publish-images is tag-gated; treat its 'skipped' result on non-tag
-          # runs as a pass. Any 'failure' anywhere else still fails the gate.
+          # runs as a pass. Code-gated jobs (static-check/build/test/IT) are
+          # also legitimately 'skipped' on docs-only PRs. Any 'failure' or
+          # 'cancelled' result fails the gate.
           if [[ "${{ contains(needs.*.result, 'failure') }}" == "true" ]]; then
-            echo "One or more jobs failed"
+            echo "One or more required jobs failed"
+            exit 1
+          fi
+          if [[ "${{ contains(needs.*.result, 'cancelled') }}" == "true" ]]; then
+            echo "One or more required jobs were cancelled"
             exit 1
           fi

--- a/.mise.toml
+++ b/.mise.toml
@@ -5,3 +5,15 @@ java = "temurin-21.0.10+7.0.LTS"
 maven = "3.9.15"
 # renovate: datasource=node-version depName=node
 node = "22.22.2"
+# renovate: datasource=github-releases depName=nektos/act
+act = "0.2.87"
+# renovate: datasource=github-releases depName=aquasecurity/trivy
+trivy = "0.70.0"
+# renovate: datasource=github-releases depName=gitleaks/gitleaks
+gitleaks = "8.30.1"
+# renovate: datasource=github-releases depName=kubernetes-sigs/kind
+kind = "0.31.0"
+# renovate: datasource=github-releases depName=kubernetes/kubernetes
+kubectl = "1.35.4"
+# renovate: datasource=github-releases depName=helm/helm
+helm = "4.1.4"

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -6,12 +6,9 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 ```bash
 make help                               # List available tasks on this project
-make deps                               # Install build dependencies via mise (reads .mise.toml)
+make deps                               # Install build dependencies via mise (reads .mise.toml). mise is the single source of truth for binaries (Java, Maven, Node, kubectl, helm, kind, act, trivy, gitleaks)
 make deps-check                         # Verify build dependencies are installed
-make deps-maven                         # Install Maven from Apache archives (CI fallback)
-make deps-act                           # Install act for local CI testing
-make deps-trivy                         # Install Trivy for security scanning
-make deps-gitleaks                      # Install gitleaks for secret scanning
+make deps-maven                         # Install Maven from Apache archives (CI fallback when mise unavailable)
 make deps-gjf                           # Download google-java-format jar
 make env-check                          # Show installed tool versions
 make build                              # Build project (skips tests)
@@ -47,9 +44,6 @@ make kind-create                        # (granular) Create KinD cluster + start
 make kind-deploy                        # (granular) Build + load images, apply k8s manifests, wait for rollout + LB IP
 make kind-undeploy                      # (granular) Delete application manifests from cluster
 make kind-destroy                       # (granular) Stop cloud-provider-kind + delete KinD cluster
-make deps-kind                          # Install KinD binary
-make deps-kubectl                       # Install kubectl binary
-make deps-helm                          # Install helm binary
 make print-deps-updates                 # Print project dependencies updates
 make update-deps                        # Update project dependencies to latest releases
 make renovate-validate                  # Validate Renovate configuration
@@ -183,6 +177,5 @@ Use the following skills when working on related files:
 | `renovate.json` | `/renovate` |
 | `README.md` | `/readme` |
 | `.github/workflows/*.{yml,yaml}` | `/ci-workflow` |
-| `CLAUDE.md` | `/claude` |
 
 When spawning subagents, always pass conventions from the respective skill into the agent's prompt.

--- a/Makefile
+++ b/Makefile
@@ -2,10 +2,11 @@
 
 SHELL := /bin/bash
 
-# Ensure tools installed to ~/.local/bin (mise, act, trivy, gitleaks, etc.) AND
-# mise shims (java, mvn, node installed by `mise install`) are on PATH for
-# every recipe. The shims path lets us run `java` / `mvn` directly even when
-# the user's shell hasn't sourced `eval "$(mise activate ...)"`. Also needed
+# Ensure tools installed to ~/.local/bin (mise itself, plus jars/scripts that
+# don't fit into mise) AND mise shims (java, mvn, node, kubectl, helm, kind,
+# act, trivy, gitleaks installed by `mise install`) are on PATH for every
+# recipe. The shims path lets us run those tools directly even when the
+# user's shell hasn't sourced `eval "$(mise activate ...)"`. Also needed
 # inside the act runner container where these paths are not preconfigured.
 # Exported so every sub-shell the recipes spawn inherits it.
 export PATH := $(HOME)/.local/share/mise/shims:$(HOME)/.local/bin:$(PATH)
@@ -15,30 +16,31 @@ APP_NAME   ?= $(notdir $(CURDIR))
 CURRENTTAG := $(shell git describe --tags --abbrev=0 2>/dev/null || echo "dev")
 
 # === Tool Versions (pinned) ===
-# Java and Maven pins live in .mise.toml; MAVEN_VERSION here only backs the
-# deps-maven fallback used inside act/CI containers that lack mise.
-# renovate: datasource=maven depName=org.apache.maven:apache-maven
-MAVEN_VERSION := 3.9.15
-# renovate: datasource=github-releases depName=nektos/act
-ACT_VERSION := 0.2.87
-# renovate: datasource=github-releases depName=aquasecurity/trivy
-TRIVY_VERSION := 0.70.0
-# renovate: datasource=github-releases depName=gitleaks/gitleaks
-GITLEAKS_VERSION := 8.30.1
+# Single source of truth: .mise.toml. Tools managed by mise (java, maven,
+# node, act, trivy, gitleaks, kind, kubectl, helm) are NOT pinned again here
+# — `mise install` is the install path; mise shims provide the binaries.
+#
+# Constants below are for tools that mise cannot manage:
+#   - GJF_VERSION:                  jar download (no binary)
+#   - KIND_NODE_IMAGE:              Docker image (not a host binary)
+#   - DAPR_HELM_VERSION:            Helm chart version (not a binary)
+#   - PLANTUML_VERSION:             Docker image
+#   - MERMAID_CLI_VERSION:          Docker image
+#   - CLOUD_PROVIDER_KIND_VERSION:  Docker image (controller runs as a
+#                                   container on the host, not a binary)
+#   - MAVEN_VERSION:                derived from .mise.toml so the
+#                                   deps-maven Apache-archives fallback (used
+#                                   only by CI containers without mise)
+#                                   tracks the same version as mise.
+MAVEN_VERSION := $(shell awk -F'"' '/^maven *= *"/ {print $$2; exit}' .mise.toml)
 # renovate: datasource=github-releases depName=google/google-java-format extractVersion=^v(?<version>.*)$
 GJF_VERSION := 1.35.0
-# renovate: datasource=github-releases depName=kubernetes-sigs/kind
-KIND_VERSION := 0.31.0
-# renovate: datasource=github-releases depName=kubernetes-sigs/cloud-provider-kind
+# renovate: datasource=docker depName=registry.k8s.io/cloud-provider-kind/cloud-controller-manager
 CLOUD_PROVIDER_KIND_VERSION := 0.10.0
 # renovate: datasource=docker depName=kindest/node
 KIND_NODE_IMAGE := kindest/node:v1.35.0@sha256:452d707d4862f52530247495d180205e029056831160e22870e37e3f6c1ac31f
 # renovate: datasource=helm depName=dapr registryUrl=https://dapr.github.io/helm-charts/
 DAPR_HELM_VERSION := 1.17.5
-# renovate: datasource=github-releases depName=kubernetes/kubernetes
-KUBECTL_VERSION := 1.35.4
-# renovate: datasource=github-releases depName=helm/helm
-HELM_VERSION := 4.1.4
 # renovate: datasource=docker depName=plantuml/plantuml
 PLANTUML_VERSION := 1.2026.2
 # renovate: datasource=docker depName=minlag/mermaid-cli
@@ -52,10 +54,8 @@ DIAGRAM_OUT := $(patsubst $(DIAGRAM_DIR)/%.puml,$(DIAGRAM_DIR)/out/%.png,$(DIAGR
 # === KinD cluster ===
 KIND_CLUSTER_NAME := $(APP_NAME)
 KIND_CONTEXT := kind-$(KIND_CLUSTER_NAME)
-KUBECTL_BIN := $(HOME)/.local/bin/kubectl
-HELM_BIN := $(HOME)/.local/bin/helm
-KUBECTL := $(KUBECTL_BIN) --context $(KIND_CONTEXT)
-HELM := $(HELM_BIN) --kube-context $(KIND_CONTEXT)
+KUBECTL := kubectl --context $(KIND_CONTEXT)
+HELM := helm --kube-context $(KIND_CONTEXT)
 # Space-separated list of services (matches Maven module dirs and k8s/ filenames)
 SERVICES := pizza-store pizza-kitchen pizza-delivery
 # Local image tag used by kind-deploy (overrides the ghcr.io/andriykalashnykov/
@@ -110,81 +110,6 @@ deps-maven:
 		mkdir -p $(HOME)/.local/bin; \
 		ln -sf "$(HOME)/.local/apache-maven-$(MAVEN_VERSION)/bin/mvn" "$(HOME)/.local/bin/mvn"; \
 	}
-
-#deps-act: @ Install act for local CI testing
-deps-act:
-	@command -v act >/dev/null 2>&1 || { echo "Installing act $(ACT_VERSION)..."; \
-		mkdir -p $(HOME)/.local/bin; \
-		curl -sSfL https://raw.githubusercontent.com/nektos/act/master/install.sh | bash -s -- -b $(HOME)/.local/bin v$(ACT_VERSION); \
-	}
-
-#deps-trivy: @ Install Trivy for security scanning
-deps-trivy:
-	@test -x $(HOME)/.local/bin/trivy || { echo "Installing trivy $(TRIVY_VERSION)..."; \
-		mkdir -p $(HOME)/.local/bin; \
-		curl -sfL https://raw.githubusercontent.com/aquasecurity/trivy/main/contrib/install.sh | sh -s -- -b $(HOME)/.local/bin v$(TRIVY_VERSION); \
-	}
-
-#deps-gitleaks: @ Install gitleaks for secret scanning
-deps-gitleaks:
-	@test -x $(HOME)/.local/bin/gitleaks || { echo "Installing gitleaks $(GITLEAKS_VERSION)..."; \
-		mkdir -p $(HOME)/.local/bin; \
-		TMPDIR=$$(mktemp -d); \
-		OS=$$(uname -s | tr '[:upper:]' '[:lower:]'); \
-		ARCH=$$(uname -m); \
-		case "$$ARCH" in x86_64) ARCH=x64;; aarch64|arm64) ARCH=arm64;; esac; \
-		curl -sSfL -o $$TMPDIR/gitleaks.tar.gz "https://github.com/gitleaks/gitleaks/releases/download/v$(GITLEAKS_VERSION)/gitleaks_$(GITLEAKS_VERSION)_$${OS}_$${ARCH}.tar.gz"; \
-		tar -xzf $$TMPDIR/gitleaks.tar.gz -C $$TMPDIR gitleaks; \
-		mv $$TMPDIR/gitleaks $(HOME)/.local/bin/gitleaks; \
-		chmod +x $(HOME)/.local/bin/gitleaks; \
-		rm -rf $$TMPDIR; \
-	}
-
-#deps-kind: @ Install KinD binary to ~/.local/bin (pinned to $(KIND_VERSION))
-deps-kind:
-	@mkdir -p $(HOME)/.local/bin
-	@if ! test -x $(HOME)/.local/bin/kind || ! $(HOME)/.local/bin/kind version 2>/dev/null | grep -q "v$(KIND_VERSION)"; then \
-		echo "Installing kind v$(KIND_VERSION)..."; \
-		OS=$$(uname -s | tr '[:upper:]' '[:lower:]'); \
-		ARCH=$$(uname -m); \
-		case "$$ARCH" in x86_64) ARCH=amd64;; aarch64|arm64) ARCH=arm64;; esac; \
-		curl -sSfL -o $(HOME)/.local/bin/kind \
-			"https://kind.sigs.k8s.io/dl/v$(KIND_VERSION)/kind-$${OS}-$${ARCH}"; \
-		chmod +x $(HOME)/.local/bin/kind; \
-	fi
-	@$(HOME)/.local/bin/kind version
-
-#deps-kubectl: @ Install kubectl to ~/.local/bin (pinned to $(KUBECTL_VERSION))
-deps-kubectl:
-	@mkdir -p $(HOME)/.local/bin
-	@if ! test -x $(KUBECTL_BIN) || ! $(KUBECTL_BIN) version --client 2>/dev/null | grep -q "v$(KUBECTL_VERSION)"; then \
-		echo "Installing kubectl v$(KUBECTL_VERSION)..."; \
-		OS=$$(uname -s | tr '[:upper:]' '[:lower:]'); \
-		ARCH=$$(uname -m); \
-		case "$$ARCH" in x86_64) ARCH=amd64;; aarch64|arm64) ARCH=arm64;; esac; \
-		curl -sSfL -o $(KUBECTL_BIN) \
-			"https://dl.k8s.io/release/v$(KUBECTL_VERSION)/bin/$${OS}/$${ARCH}/kubectl"; \
-		chmod +x $(KUBECTL_BIN); \
-	fi
-	@$(KUBECTL_BIN) version --client | head -1
-
-#deps-helm: @ Install helm to ~/.local/bin (pinned to $(HELM_VERSION))
-deps-helm:
-	@mkdir -p $(HOME)/.local/bin
-	@if ! test -x $(HELM_BIN) || ! $(HELM_BIN) version --short 2>/dev/null | grep -q "v$(HELM_VERSION)"; then \
-		echo "Installing helm v$(HELM_VERSION)..."; \
-		OS=$$(uname -s | tr '[:upper:]' '[:lower:]'); \
-		ARCH=$$(uname -m); \
-		case "$$ARCH" in x86_64) ARCH=amd64;; aarch64|arm64) ARCH=arm64;; esac; \
-		TMPDIR=$$(mktemp -d); \
-		curl -sSfL -o $$TMPDIR/helm.tgz \
-			"https://get.helm.sh/helm-v$(HELM_VERSION)-$${OS}-$${ARCH}.tar.gz"; \
-		tar -xzf $$TMPDIR/helm.tgz -C $$TMPDIR; \
-		mv $$TMPDIR/$${OS}-$${ARCH}/helm $(HELM_BIN); \
-		rm -rf $$TMPDIR; \
-		chmod +x $(HELM_BIN); \
-	fi
-	@$(HELM_BIN) version --short
 
 #deps-gjf: @ Download google-java-format jar
 deps-gjf: $(GJF_JAR)
@@ -248,17 +173,17 @@ format-check: deps-check $(GJF_JAR)
 			-jar $(GJF_JAR) --set-exit-if-changed --dry-run > /dev/null
 
 #trivy-fs: @ Scan filesystem for HIGH/CRITICAL vulnerabilities, secrets, and misconfigurations
-trivy-fs: deps-trivy
-	@$(HOME)/.local/bin/trivy fs --severity HIGH,CRITICAL --exit-code 1 .
+trivy-fs:
+	@trivy fs --severity HIGH,CRITICAL --exit-code 1 .
 
 #trivy-config: @ Scan K8s manifests for security misconfigurations (KSV-*)
-trivy-config: deps-trivy
-	@$(HOME)/.local/bin/trivy config --severity HIGH,CRITICAL --exit-code 1 k8s/
-	@$(HOME)/.local/bin/trivy config --severity HIGH,CRITICAL --exit-code 1 k8s-dapr-shared/
+trivy-config:
+	@trivy config --severity HIGH,CRITICAL --exit-code 1 k8s/
+	@trivy config --severity HIGH,CRITICAL --exit-code 1 k8s-dapr-shared/
 
 #secrets: @ Scan for leaked secrets with gitleaks
-secrets: deps-gitleaks
-	@$(HOME)/.local/bin/gitleaks detect --source . --verbose --redact
+secrets:
+	@gitleaks detect --source . --verbose --redact
 
 #deps-prune: @ Analyze Maven dependencies (advisory)
 deps-prune: deps-check
@@ -329,7 +254,7 @@ run: build
 ci: clean deps static-check test integration-test build coverage-check
 
 #ci-run: @ Run GitHub Actions workflow locally using act (jobs serialized)
-ci-run: deps-act
+ci-run: deps
 	@# Prune stale containers first — Docker's overlayfs can hit a race
 	@# (moby/moby#49228) where a leftover container's RWLayer is nil,
 	@# producing exit 137 that looks like OOM but is a daemon bug.
@@ -354,17 +279,29 @@ ci-run: deps-act
 	@#
 	@# Random artifact-server port + per-run tmpdir so concurrent
 	@# `make ci-run` invocations across repos don't race on act's default.
+	@#
+	@# Synthetic event payload: act push events do NOT populate
+	@# `repository.default_branch` or `event.before`, both of which
+	@# `dorny/paths-filter` requires to compute the diff. Provide them so
+	@# the `changes` job resolves and downstream gated jobs run as on real CI.
 	@ACT_PORT=$$(shuf -i 40000-59999 -n 1); \
 	ARTIFACT_PATH=$$(mktemp -d -t act-artifacts.XXXXXX); \
-	for j in static-check build test integration-test; do \
+	EVENT_PATH=$$(mktemp -t act-event.XXXXXX.json); \
+	BEFORE=$$(git rev-parse HEAD~1 2>/dev/null || git rev-parse HEAD); \
+	HEAD=$$(git rev-parse HEAD); \
+	printf '{"repository":{"default_branch":"main","name":"%s","owner":{"login":"%s"}},"before":"%s","after":"%s","ref":"refs/heads/main","pusher":{"name":"local"}}' \
+		"$(APP_NAME)" "local" "$$BEFORE" "$$HEAD" > "$$EVENT_PATH"; \
+	for j in changes static-check build test integration-test; do \
 		echo ""; \
 		echo "============================================================"; \
 		echo "  act push --job $$j"; \
 		echo "============================================================"; \
 		act push --job $$j --container-architecture linux/amd64 \
+			--eventpath "$$EVENT_PATH" \
 			--artifact-server-port "$$ACT_PORT" \
 			--artifact-server-path "$$ARTIFACT_PATH" || exit 1; \
-	done
+	done; \
+	rm -f "$$EVENT_PATH"
 
 #cve-check: @ OWASP dependency vulnerability scan
 cve-check: deps-check
@@ -379,7 +316,7 @@ coverage-generate: deps-check
 	@mvn -B verify -P integration-test -Ddependency-check.skip=true jacoco:report
 
 #coverage-check: @ Verify merged coverage meets minimum threshold (>=80%)
-coverage-check: deps-check
+coverage-check: coverage-generate
 	@mvn -B jacoco:check
 
 #coverage-open: @ Open code coverage report
@@ -399,19 +336,13 @@ update-deps: print-deps-updates
 	@mvn -B versions:use-latest-releases versions:commit
 
 #renovate-validate: @ Validate Renovate configuration
-renovate-validate:
-	@if ! command -v node >/dev/null 2>&1; then \
-		if command -v mise >/dev/null 2>&1; then \
-			mise exec -- npx --yes renovate --platform=local; \
-		else \
-			echo "Error: node is required. Run 'make deps' to install via mise."; \
-			exit 1; \
-		fi; \
-	else \
-		npx --yes renovate --platform=local; \
-	fi
+renovate-validate: deps
+	@npx --yes renovate --platform=local
 
 #image-build: @ Build OCI images for all services via spring-boot:build-image (tag $(E2E_IMAGE_TAG))
+# Note: no `build` prerequisite — spring-boot:build-image is self-contained
+# (compiles + packages the jar in-process before assembling the OCI image),
+# so a separate `build` step would only duplicate work.
 image-build: deps-check
 	@for svc in $(SERVICES); do \
 		echo "--- Building image for $$svc ---"; \
@@ -423,7 +354,7 @@ image-build: deps-check
 	done
 
 #image-scan: @ Scan built OCI images for HIGH/CRITICAL CVEs (covers Paketo base layers — Renovate blind spot)
-image-scan: image-build deps-trivy
+image-scan: image-build
 	@# spring-boot:build-image uses Paketo CNB builders; the resulting image
 	@# layers (JRE + base OS) are NOT visible to `trivy-fs` (which scans the
 	@# workspace) or `cve-check` (which scans Maven deps). Scanning the built
@@ -431,7 +362,7 @@ image-scan: image-build deps-trivy
 	@# (only advisories with an available patch fail the build).
 	@for svc in $(SERVICES); do \
 		echo "--- Scanning image $$svc:$(E2E_IMAGE_TAG) ---"; \
-		$(HOME)/.local/bin/trivy image \
+		trivy image \
 			--severity HIGH,CRITICAL \
 			--ignore-unfixed \
 			--exit-code 1 \
@@ -441,7 +372,7 @@ image-scan: image-build deps-trivy
 	done
 
 #kind-create: @ Create KinD cluster, start cloud-provider-kind LB controller, install Dapr via Helm
-kind-create: deps-kind deps-kubectl deps-helm
+kind-create: deps-check
 	@# Preflight: warn if sibling KinD clusters share the default `kind` Docker
 	@# bridge network. Their kube-proxies both DNAT 10.96.0.1:443 (in-cluster
 	@# API ClusterIP) → their own API server, and the rule sets collide on the
@@ -460,11 +391,11 @@ kind-create: deps-kind deps-kubectl deps-helm
 		echo "      kind delete cluster --name <name>"; \
 		echo ""; \
 	fi
-	@if $(HOME)/.local/bin/kind get clusters 2>/dev/null | grep -q "^$(KIND_CLUSTER_NAME)$$"; then \
+	@if kind get clusters 2>/dev/null | grep -q "^$(KIND_CLUSTER_NAME)$$"; then \
 		echo "KinD cluster $(KIND_CLUSTER_NAME) already exists; reusing."; \
 	else \
 		echo "Creating KinD cluster $(KIND_CLUSTER_NAME) with image $(KIND_NODE_IMAGE)..."; \
-		$(HOME)/.local/bin/kind create cluster \
+		kind create cluster \
 			--name $(KIND_CLUSTER_NAME) \
 			--image $(KIND_NODE_IMAGE) \
 			--config k8s/kind-config.yaml \
@@ -495,7 +426,7 @@ kind-create: deps-kind deps-kubectl deps-helm
 kind-deploy: kind-create image-build image-scan
 	@echo "--- Loading images into KinD cluster ---"
 	@for svc in $(SERVICES); do \
-		$(HOME)/.local/bin/kind load docker-image $$svc:$(E2E_IMAGE_TAG) \
+		kind load docker-image $$svc:$(E2E_IMAGE_TAG) \
 			--name $(KIND_CLUSTER_NAME); \
 	done
 	@echo "--- Deploying Redis (backs Dapr pubsub + state store for e2e) ---"
@@ -532,7 +463,7 @@ kind-deploy: kind-create image-build image-scan
 	echo "FAIL: pizza-store did not get a LoadBalancer IP"; exit 1
 
 #kind-undeploy: @ Remove app and Dapr components from KinD cluster
-kind-undeploy: deps-kubectl
+kind-undeploy: deps-check
 	@for svc in $(SERVICES); do \
 		$(KUBECTL) delete -f k8s/$$svc.yaml --ignore-not-found 2>/dev/null || true; \
 	done
@@ -541,9 +472,9 @@ kind-undeploy: deps-kubectl
 	@$(KUBECTL) delete -f k8s/redis-e2e.yaml --ignore-not-found 2>/dev/null || true
 
 #kind-destroy: @ Delete the KinD cluster and stop cloud-provider-kind
-kind-destroy: deps-kind
+kind-destroy: deps-check
 	@docker rm -f cloud-provider-kind 2>/dev/null || true
-	@$(HOME)/.local/bin/kind delete cluster --name $(KIND_CLUSTER_NAME) 2>/dev/null || true
+	@kind delete cluster --name $(KIND_CLUSTER_NAME) 2>/dev/null || true
 
 #kind-up: @ Alias for kind-create + kind-deploy (full stack up)
 kind-up: kind-deploy
@@ -595,12 +526,11 @@ release: pre-release
 	@git tag -a "v$(VERSION)" -m "Release v$(VERSION)"
 	@echo "Release tag v$(VERSION) created. Push with: git push origin v$(VERSION)"
 
-.PHONY: help deps deps-check deps-maven deps-act deps-trivy deps-gitleaks deps-gjf \
-	deps-kind deps-kubectl deps-helm \
+.PHONY: help deps deps-check deps-maven deps-gjf \
 	env-check clean build test integration-test lint format format-check \
 	trivy-fs trivy-config secrets deps-prune deps-prune-check static-check run \
 	ci ci-run cve-check coverage-generate coverage-check coverage-open \
 	print-deps-updates update-deps renovate-validate \
-	image-build image-scan mirror-images kind-create kind-deploy kind-undeploy kind-destroy \
+	image-build image-scan kind-create kind-deploy kind-undeploy kind-destroy \
 	kind-up kind-down e2e pre-release release \
 	diagrams diagrams-clean diagrams-check mermaid-lint

--- a/README.md
+++ b/README.md
@@ -5,9 +5,7 @@
 
 # Pizza on Dapr — Spring Boot 4 Microservices Reference
 
-Reference implementation of a three-service Java microservice platform on [Dapr](https://dapr.io), demonstrating PubSub, State Store, and Service Invocation building blocks with [Spring Boot 4](https://spring.io/projects/spring-boot) and [Testcontainers](https://testcontainers.com). Deployable on any Kubernetes cluster or runnable locally with Docker.
-
-[Quarkus implementation available here (Thanks to @mcruzdev1!)](https://github.com/mcruzdev/pizza-quarkus)
+Reference implementation of a three-service Java microservice platform on [Dapr](https://dapr.io), demonstrating PubSub, State Store, and Service Invocation building blocks with [Spring Boot 4](https://spring.io/projects/spring-boot) and [Testcontainers](https://testcontainers.com). Deployable on any Kubernetes cluster or run locally on KinD via `make kind-up`; integration tests use Testcontainers (no Dapr install required).
 
 ```mermaid
 C4Context
@@ -49,7 +47,7 @@ C4Context
 make deps          # install build dependencies via mise (reads .mise.toml)
 make build         # build project (skips tests)
 make test          # run unit tests (requires Docker)
-make run           # start the application
+make run           # start the application (dev only — needs a Dapr sidecar to serve orders end-to-end; see Kubernetes Deployment for the full stack)
 # Open http://localhost:8080
 ```
 
@@ -126,7 +124,7 @@ sequenceDiagram
   S->>C: WS ORDER_COMPLETED
 ```
 
-### Deployment
+### Deployment View
 
 <img src="docs/diagrams/out/c4-deployment.png" alt="C4 Deployment diagram (Kubernetes)" width="800">
 
@@ -137,6 +135,26 @@ sequenceDiagram
 - PubSub and State Store components resolve to Redis for e2e (`k8s/components-e2e.yaml`) and to Kafka + PostgreSQL in production.
 
 Source files live in [`docs/diagrams/`](docs/diagrams/); regenerate the PNGs with `make diagrams`.
+
+## API
+
+The three services expose the following HTTP surface. Cross-service calls go through Dapr service invocation (`dapr-app-id` header); the WebSocket topic is broadcast to browsers by `pizza-store`.
+
+| Method | Path | Service | Purpose |
+|--------|------|---------|---------|
+| `POST` | `/order` | pizza-store | Place a new order; persists to the `kvstore` State Store and triggers downstream service invocation |
+| `GET` | `/order` | pizza-store | List orders held in the State Store |
+| `POST` | `/events` | pizza-store | CloudEvent subscriber (`Content-Type: application/cloudevents+json`); routes `ORDER_*` events to State Store updates and WebSocket broadcasts |
+| `PUT` | `/prepare` | pizza-kitchen | Receive an order via Dapr invoke; publishes `ORDER_IN_PREPARATION` and `ORDER_READY` to the `pubsub` component |
+| `PUT` | `/deliver` | pizza-delivery | Receive an order via Dapr invoke; publishes `ORDER_ON_ITS_WAY` (×3) and `ORDER_COMPLETED` |
+| `WS` | `/ws` → `/topic/events` | pizza-store | STOMP broker; clients subscribe to `/topic/events` for live order status |
+| `GET` | `/actuator/health` | all three | Spring Boot Actuator liveness/readiness probe |
+
+CloudEvents can be replayed locally against a running pizza-store using [`httpie`](https://httpie.io/):
+
+```bash
+http :8080/events Content-Type:application/cloudevents+json < pizza-store/event-in-prep.json
+```
 
 ## Testing
 
@@ -159,12 +177,6 @@ Three test layers are exposed:
 | Unit | `make test` | Surefire runs `**/*Test.java` against in-memory PubSub Dapr sidecars | ~30 s |
 | Integration | `make integration-test` | Failsafe runs `**/*IT.java`: `PizzaStoreStateStoreIT` (real `kvstore` round-trip), `KitchenInvocationIT` / `DeliveryInvocationIT` (service-invocation contract via WireMock), `WebSocketBroadcastIT` (STOMP broadcast of `ORDER_PLACED`) | ~1 min |
 | E2E | `make e2e` | KinD + cloud-provider-kind + Dapr Helm + `e2e/e2e-test.sh` asserts the full `store → kitchen → store → delivery → store` lifecycle reaches `Status.completed` through the LoadBalancer | ~2 min |
-
-Once the service is up, events from the Kitchen and Delivery services can be simulated by posting CloudEvents to the `/events` endpoint. Using [`httpie`](https://httpie.io/):
-
-```bash
-http :8080/events Content-Type:application/cloudevents+json < pizza-store/event-in-prep.json
-```
 
 ## Kubernetes Deployment
 
@@ -297,18 +309,14 @@ Run `make help` to see all available targets.
 
 ### Dependencies & Tools
 
+`mise` is the single source of truth for binary tools (Java, Maven, Node, kubectl, helm, kind, act, trivy, gitleaks). `make deps` invokes `mise install` against `.mise.toml` and verifies the resulting shims.
+
 | Target | Description |
 |--------|-------------|
 | `make deps` | Install build dependencies via mise (reads `.mise.toml`) |
 | `make deps-check` | Verify build dependencies are installed |
 | `make deps-maven` | Install Maven from Apache archives (CI fallback when mise unavailable) |
-| `make deps-act` | Install act |
-| `make deps-trivy` | Install Trivy |
-| `make deps-gitleaks` | Install gitleaks |
 | `make deps-gjf` | Download google-java-format jar |
-| `make deps-kind` | Install KinD binary |
-| `make deps-kubectl` | Install kubectl binary |
-| `make deps-helm` | Install helm binary |
 | `make env-check` | Show installed tool versions |
 
 ### Utilities
@@ -327,13 +335,15 @@ GitHub Actions runs on push to `main`, tags `v*`, pull requests, a weekly schedu
 
 | Job | Triggers | Depends on | Steps |
 |-----|----------|-----------|-------|
-| **static-check** | push, PR, tags | — | `make static-check` (format-check, Checkstyle, trivy-fs, trivy-config, gitleaks, diagrams-check, mermaid-lint); `fetch-depth: 0` so gitleaks can walk history |
-| **build** | push, PR, tags | `static-check` | `make build`; tag-gated artifact upload of `pizza-*/target/*.jar` |
-| **test** | push, PR, tags | `static-check` | `make test` (Surefire unit tests only — fast feedback) |
-| **integration-test** | push, PR, tags | `static-check` | `make coverage-generate` + `make coverage-check`; runs surefire + failsafe + merged-coverage gate; uploads JaCoCo report |
-| **cve-check** | tag push, weekly cron (Mon 06:00 UTC), `workflow_dispatch` | `build`, `test`, `integration-test` | `make cve-check` (OWASP dependency-check), NVD cache, HTML report upload |
-| **e2e** | push to `main`/tag, PR label `run-e2e`, `workflow_dispatch` | `build`, `test`, `integration-test` | `make deps-kind deps-kubectl deps-helm` + `make e2e`; collects pod logs + cluster events on failure |
-| **ci-pass** | always | all above | Gate job that fails if any needed job failed (required-status-check target) |
+| **changes** | push, PR, tags | — | `dorny/paths-filter` emits `code` (binary skip-everything-on-docs-only) and `e2e` (heavy KinD job gating) flags consumed by downstream jobs |
+| **static-check** | push, PR, tags (`code` flag) | `changes` | `make static-check` (format-check, Checkstyle, trivy-fs, trivy-config, gitleaks, diagrams-check, mermaid-lint); `fetch-depth: 0` so gitleaks can walk history |
+| **build** | push, PR, tags (`code` flag) | `changes`, `static-check` | `make build`; tag-gated artifact upload of `pizza-*/target/*.jar` |
+| **test** | push, PR, tags (`code` flag) | `changes`, `static-check` | `make test` (Surefire unit tests only — fast feedback) |
+| **integration-test** | push, PR, tags (`code` flag) | `changes`, `static-check` | `make coverage-generate` + `make coverage-check`; runs surefire + failsafe + merged-coverage gate; uploads JaCoCo report |
+| **cve-check** | tag push, weekly cron (Mon 06:00 UTC), `workflow_dispatch` | `static-check` | `make cve-check` (OWASP dependency-check), NVD cache, HTML report upload |
+| **e2e** | push to `main`/tag, PR label `run-e2e` or `e2e` flag, `workflow_dispatch` | `changes`, `build`, `test` | `jdx/mise-action` installs kind/kubectl/helm/trivy/gitleaks via `mise`, then `make e2e`; collects pod logs + cluster events on failure |
+| **publish-images** | tag push only | `static-check`, `build`, `test`, `integration-test`, `e2e` | `make image-scan` builds + scans Paketo CNB images; tags and pushes `ghcr.io/<owner>/<repo>/pizza-*:<version>` and `:latest` |
+| **ci-pass** | always | all above | Gate job that fails if any needed job failed or was cancelled (required-status-check target) |
 
 ### Required Secrets and Variables
 
@@ -345,12 +355,16 @@ Set secrets via **Settings > Secrets and variables > Actions > New repository se
 
 [Renovate](https://docs.renovatebot.com/) keeps dependencies up to date with platform automerge enabled.
 
+## Contributing
+
+Contributions welcome — [open an issue](https://github.com/AndriyKalashnykov/dapr-java/issues) or submit a pull request.
+
+## Related Projects
+
+- Quarkus port: [pizza-quarkus](https://github.com/mcruzdev/pizza-quarkus) by @mcruzdev.
+
 ## Resources and References
 
 - [Dapr For Java Developers](https://dzone.com/articles/dapr-for-java-developers)
 - [Platform Engineering on Kubernetes Book](http://mng.bz/jjKP)
 - [Cloud Native Local Development with Dapr and Testcontainers](https://www.diagrid.io/blog/cloud-native-local-development)
-
-## Contributing
-
-Contributions welcome — [open an issue](https://github.com/AndriyKalashnykov/dapr-java/issues) or submit a pull request.

--- a/pizza-store/src/test/java/io/diagrid/dapr/DeliveryInvocationIT.java
+++ b/pizza-store/src/test/java/io/diagrid/dapr/DeliveryInvocationIT.java
@@ -17,10 +17,10 @@ import java.time.Duration;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.boot.test.web.server.LocalServerPort;
 import org.springframework.boot.testcontainers.context.ImportTestcontainers;
 import org.springframework.test.context.DynamicPropertyRegistry;
 import org.springframework.test.context.DynamicPropertySource;
+import org.springframework.test.util.TestSocketUtils;
 import org.wiremock.integrations.testcontainers.WireMockContainer;
 
 /**
@@ -31,16 +31,20 @@ import org.wiremock.integrations.testcontainers.WireMockContainer;
  */
 @SpringBootTest(
     classes = PizzaStoreAppTest.class,
-    webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
+    webEnvironment = SpringBootTest.WebEnvironment.DEFINED_PORT)
 @ImportTestcontainers
 public class DeliveryInvocationIT {
 
   private static final String ORDER_ID = "it-delivery-order-1";
 
+  // Allocate a free port at class-load time so DaprContainer's app channel
+  // and Spring's embedded Tomcat agree on the port.
+  private static final int APP_PORT = TestSocketUtils.findAvailableTcpPort();
+
   static DaprContainer dapr =
       new DaprContainer(DaprContainer.getDefaultImageName())
           .withAppName("local-dapr-app")
-          .withAppPort(8080)
+          .withAppPort(APP_PORT)
           .withAppChannelAddress("host.testcontainers.internal")
           .withExtraHost("host.testcontainers.internal", "host-gateway")
           .withComponent(
@@ -53,6 +57,7 @@ public class DeliveryInvocationIT {
 
   @DynamicPropertySource
   static void daprProperties(DynamicPropertyRegistry registry) {
+    registry.add("server.port", () -> APP_PORT);
     registry.add("dapr.grpc.port", dapr::getGrpcPort);
     registry.add("dapr.http.port", dapr::getHttpPort);
     registry.add("DAPR_HTTP_ENDPOINT", wireMock::getBaseUrl);
@@ -62,13 +67,7 @@ public class DeliveryInvocationIT {
   void setSystemProperties() {
     System.setProperty("dapr.grpc.port", String.valueOf(dapr.getGrpcPort()));
     System.setProperty("dapr.http.port", String.valueOf(dapr.getHttpPort()));
-  }
-
-  @LocalServerPort private int port;
-
-  @BeforeEach
-  public void setUp() {
-    RestAssured.port = port;
+    RestAssured.port = APP_PORT;
     WireMock.configureFor(wireMock.getHost(), wireMock.getPort());
     WireMock.reset();
     WireMock.stubFor(put(urlEqualTo("/prepare")).willReturn(aResponse().withStatus(200)));

--- a/pizza-store/src/test/java/io/diagrid/dapr/KitchenInvocationIT.java
+++ b/pizza-store/src/test/java/io/diagrid/dapr/KitchenInvocationIT.java
@@ -25,10 +25,10 @@ import java.util.Collections;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.boot.test.web.server.LocalServerPort;
 import org.springframework.boot.testcontainers.context.ImportTestcontainers;
 import org.springframework.test.context.DynamicPropertyRegistry;
 import org.springframework.test.context.DynamicPropertySource;
+import org.springframework.test.util.TestSocketUtils;
 import org.wiremock.integrations.testcontainers.WireMockContainer;
 
 /**
@@ -41,14 +41,18 @@ import org.wiremock.integrations.testcontainers.WireMockContainer;
  */
 @SpringBootTest(
     classes = PizzaStoreAppTest.class,
-    webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
+    webEnvironment = SpringBootTest.WebEnvironment.DEFINED_PORT)
 @ImportTestcontainers
 public class KitchenInvocationIT {
+
+  // Allocate a free port at class-load time so DaprContainer's app channel
+  // and Spring's embedded Tomcat agree on the port.
+  private static final int APP_PORT = TestSocketUtils.findAvailableTcpPort();
 
   static DaprContainer dapr =
       new DaprContainer(DaprContainer.getDefaultImageName())
           .withAppName("local-dapr-app")
-          .withAppPort(8080)
+          .withAppPort(APP_PORT)
           .withAppChannelAddress("host.testcontainers.internal")
           .withExtraHost("host.testcontainers.internal", "host-gateway")
           .withComponent(new Component("kvstore", "state.in-memory", "v1", Collections.emptyMap()))
@@ -59,6 +63,7 @@ public class KitchenInvocationIT {
 
   @DynamicPropertySource
   static void daprProperties(DynamicPropertyRegistry registry) {
+    registry.add("server.port", () -> APP_PORT);
     registry.add("dapr.grpc.port", dapr::getGrpcPort);
     registry.add("dapr.http.port", dapr::getHttpPort);
     registry.add("DAPR_HTTP_ENDPOINT", wireMock::getBaseUrl);
@@ -68,13 +73,7 @@ public class KitchenInvocationIT {
   void setSystemProperties() {
     System.setProperty("dapr.grpc.port", String.valueOf(dapr.getGrpcPort()));
     System.setProperty("dapr.http.port", String.valueOf(dapr.getHttpPort()));
-  }
-
-  @LocalServerPort private int port;
-
-  @BeforeEach
-  public void setUp() {
-    RestAssured.port = port;
+    RestAssured.port = APP_PORT;
     WireMock.configureFor(wireMock.getHost(), wireMock.getPort());
     WireMock.reset();
     // Kitchen stub

--- a/pizza-store/src/test/java/io/diagrid/dapr/OrderCompletedStateIT.java
+++ b/pizza-store/src/test/java/io/diagrid/dapr/OrderCompletedStateIT.java
@@ -28,16 +28,19 @@ import org.springframework.test.util.TestSocketUtils;
 import org.wiremock.integrations.testcontainers.WireMockContainer;
 
 /**
- * Integration test exercising the real Dapr state store round-trip. Uses an in-memory state store
- * and in-memory pub/sub component so events emitted by {@code PizzaStore#placeOrder} are accepted
- * by the sidecar. Kitchen / delivery service invocation is stubbed via WireMock — this IT is scoped
- * to state persistence, not service invocation.
+ * Integration test covering the ORDER_COMPLETED branch of {@link PizzaStore#receiveEvents}: when a
+ * CloudEvent of type {@code order-completed} arrives, the store must upsert the order with {@code
+ * Status.completed} so the subsequent {@code GET /order} reflects the terminal state.
+ *
+ * <p>The existing {@link PizzaStoreStateStoreIT} only exercises {@code POST /order} persistence;
+ * this IT closes the coverage gap on the second branch of {@code receiveEvents} (the first branch,
+ * ORDER_READY, is covered by {@link DeliveryInvocationIT}).
  */
 @SpringBootTest(
     classes = PizzaStoreAppTest.class,
     webEnvironment = SpringBootTest.WebEnvironment.DEFINED_PORT)
 @ImportTestcontainers
-public class PizzaStoreStateStoreIT {
+public class OrderCompletedStateIT {
 
   // Allocate a free port at class-load time so DaprContainer's app channel
   // and Spring's embedded Tomcat agree on the port.
@@ -74,15 +77,16 @@ public class PizzaStoreStateStoreIT {
   }
 
   @Test
-  public void storesAndRetrievesOrder() {
-    Order submitted =
+  public void orderCompletedEventTransitionsStatusToCompleted() {
+    // Place a fresh order so the state store has a row keyed on an id we control downstream.
+    Order placed =
         new Order(
-            new Customer("alice", "alice@example.com"),
-            Arrays.asList(new OrderItem(PizzaType.margherita, 2)));
+            new Customer("frank", "frank@example.com"),
+            Arrays.asList(new OrderItem(PizzaType.margherita, 1)));
 
     String orderId =
         with()
-            .body(submitted)
+            .body(placed)
             .contentType(ContentType.JSON)
             .when()
             .request("POST", "/order")
@@ -93,7 +97,48 @@ public class PizzaStoreStateStoreIT {
             .extract()
             .path("id");
 
-    // placeOrder persists asynchronously on a background thread; poll the state store.
+    // Confirm the order landed before posting the completion event.
+    await()
+        .atMost(Duration.ofSeconds(15))
+        .pollInterval(Duration.ofMillis(500))
+        .untilAsserted(
+            () -> get("/order").then().statusCode(200).body("orders.id", hasItem(orderId)));
+
+    // Post an ORDER_COMPLETED CloudEvent referencing the same order id. PizzaStore's
+    // receiveEvents handler should upsert the row with status=completed.
+    String completedEvent =
+        """
+        {
+            "specversion": "1.0",
+            "type": "com.dapr.event.sent",
+            "source": "delivery-service",
+            "data": {
+                "type": "order-completed",
+                "service": "delivery",
+                "message": "Your Order has been delivered.",
+                "order": {
+                    "customer": {"name": "frank", "email": "frank@example.com"},
+                    "items": [{"type": "margherita", "amount": 1}],
+                    "id": "%s",
+                    "orderDate": "2026-05-01T12:00:00.000+00:00",
+                    "status": "delivery"
+                }
+            }
+        }
+        """
+            .formatted(orderId);
+
+    with()
+        .body(completedEvent)
+        .contentType("application/cloudevents+json")
+        .when()
+        .request("POST", "/events")
+        .then()
+        .assertThat()
+        .statusCode(200);
+
+    // The state store write happens synchronously inside receiveEvents, but the response
+    // path serializes through Tomcat's worker pool — give it a brief poll window.
     await()
         .atMost(Duration.ofSeconds(15))
         .pollInterval(Duration.ofMillis(500))
@@ -104,56 +149,6 @@ public class PizzaStoreStateStoreIT {
                     .assertThat()
                     .statusCode(200)
                     .body("orders.id", hasItem(orderId))
-                    .body("orders.customer.name", hasItem("alice"))
-                    .body("orders.customer.email", hasItem("alice@example.com")));
-  }
-
-  @Test
-  public void persistsMultipleOrders() {
-    Order order1 =
-        new Order(
-            new Customer("dave", "dave@example.com"),
-            Arrays.asList(new OrderItem(PizzaType.vegetarian, 3)));
-    Order order2 =
-        new Order(
-            new Customer("erin", "erin@example.com"),
-            Arrays.asList(new OrderItem(PizzaType.margherita, 2)));
-
-    String firstId =
-        with()
-            .body(order1)
-            .contentType(ContentType.JSON)
-            .when()
-            .request("POST", "/order")
-            .then()
-            .assertThat()
-            .statusCode(200)
-            .extract()
-            .path("id");
-    String secondId =
-        with()
-            .body(order2)
-            .contentType(ContentType.JSON)
-            .when()
-            .request("POST", "/order")
-            .then()
-            .assertThat()
-            .statusCode(200)
-            .extract()
-            .path("id");
-
-    await()
-        .atMost(Duration.ofSeconds(15))
-        .pollInterval(Duration.ofMillis(500))
-        .untilAsserted(
-            () ->
-                get("/order")
-                    .then()
-                    .assertThat()
-                    .statusCode(200)
-                    .body("orders.id", hasItem(firstId))
-                    .body("orders.id", hasItem(secondId))
-                    .body("orders.customer.name", hasItem("dave"))
-                    .body("orders.customer.name", hasItem("erin")));
+                    .body("orders.status", hasItem("completed")));
   }
 }

--- a/pizza-store/src/test/java/io/diagrid/dapr/PizzaStoreTest.java
+++ b/pizza-store/src/test/java/io/diagrid/dapr/PizzaStoreTest.java
@@ -15,22 +15,30 @@ import java.util.Arrays;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.boot.test.web.server.LocalServerPort;
 import org.springframework.boot.testcontainers.context.ImportTestcontainers;
 import org.springframework.test.context.DynamicPropertyRegistry;
 import org.springframework.test.context.DynamicPropertySource;
+import org.springframework.test.util.TestSocketUtils;
 import org.wiremock.integrations.testcontainers.WireMockContainer;
 
 @SpringBootTest(
     classes = PizzaStoreAppTest.class,
-    webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
+    webEnvironment = SpringBootTest.WebEnvironment.DEFINED_PORT)
 @ImportTestcontainers
 public class PizzaStoreTest {
+
+  // Allocate a free port at class-load time so this test can run in parallel
+  // with other DEFINED_PORT tests (e.g. on the same host when act runs the
+  // `test` and `integration-test` workflow jobs concurrently). Both
+  // DaprContainer's app channel and Spring's embedded Tomcat bind to
+  // APP_PORT — eliminates the latent mismatch where the sidecar was told
+  // 8080 but Spring landed on a random port.
+  private static final int APP_PORT = TestSocketUtils.findAvailableTcpPort();
 
   static DaprContainer dapr =
       new DaprContainer(DaprContainer.getDefaultImageName())
           .withAppName("local-dapr-app")
-          .withAppPort(8080)
+          .withAppPort(APP_PORT)
           .withAppChannelAddress("host.testcontainers.internal")
           .withExtraHost("host.testcontainers.internal", "host-gateway");
 
@@ -41,6 +49,7 @@ public class PizzaStoreTest {
 
   @DynamicPropertySource
   static void daprProperties(DynamicPropertyRegistry registry) {
+    registry.add("server.port", () -> APP_PORT);
     registry.add("dapr.grpc.port", dapr::getGrpcPort);
     registry.add("dapr.http.port", dapr::getHttpPort);
     registry.add("DAPR_HTTP_ENDPOINT", wireMock::getBaseUrl);
@@ -50,13 +59,7 @@ public class PizzaStoreTest {
   void setSystemProperties() {
     System.setProperty("dapr.grpc.port", String.valueOf(dapr.getGrpcPort()));
     System.setProperty("dapr.http.port", String.valueOf(dapr.getHttpPort()));
-  }
-
-  @LocalServerPort private int port;
-
-  @BeforeEach
-  public void setUp() {
-    RestAssured.port = port;
+    RestAssured.port = APP_PORT;
   }
 
   @Test

--- a/pizza-store/src/test/java/io/diagrid/dapr/WebSocketBroadcastIT.java
+++ b/pizza-store/src/test/java/io/diagrid/dapr/WebSocketBroadcastIT.java
@@ -24,7 +24,6 @@ import java.util.concurrent.LinkedBlockingQueue;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.boot.test.web.server.LocalServerPort;
 import org.springframework.boot.testcontainers.context.ImportTestcontainers;
 import org.springframework.messaging.converter.JacksonJsonMessageConverter;
 import org.springframework.messaging.simp.stomp.StompFrameHandler;
@@ -33,6 +32,7 @@ import org.springframework.messaging.simp.stomp.StompSession;
 import org.springframework.messaging.simp.stomp.StompSessionHandlerAdapter;
 import org.springframework.test.context.DynamicPropertyRegistry;
 import org.springframework.test.context.DynamicPropertySource;
+import org.springframework.test.util.TestSocketUtils;
 import org.springframework.web.socket.client.standard.StandardWebSocketClient;
 import org.springframework.web.socket.messaging.WebSocketStompClient;
 import org.wiremock.integrations.testcontainers.WireMockContainer;
@@ -44,14 +44,19 @@ import org.wiremock.integrations.testcontainers.WireMockContainer;
  */
 @SpringBootTest(
     classes = PizzaStoreAppTest.class,
-    webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
+    webEnvironment = SpringBootTest.WebEnvironment.DEFINED_PORT)
 @ImportTestcontainers
 public class WebSocketBroadcastIT {
+
+  // Allocate a free port at class-load time so DaprContainer's app channel
+  // and Spring's embedded Tomcat agree on the port. The WebSocket STOMP
+  // client also needs to know the port — connects via ws://localhost:APP_PORT/ws.
+  private static final int APP_PORT = TestSocketUtils.findAvailableTcpPort();
 
   static DaprContainer dapr =
       new DaprContainer(DaprContainer.getDefaultImageName())
           .withAppName("local-dapr-app")
-          .withAppPort(8080)
+          .withAppPort(APP_PORT)
           .withAppChannelAddress("host.testcontainers.internal")
           .withExtraHost("host.testcontainers.internal", "host-gateway")
           .withComponent(new Component("kvstore", "state.in-memory", "v1", Collections.emptyMap()))
@@ -65,6 +70,7 @@ public class WebSocketBroadcastIT {
 
   @DynamicPropertySource
   static void daprProperties(DynamicPropertyRegistry registry) {
+    registry.add("server.port", () -> APP_PORT);
     registry.add("dapr.grpc.port", dapr::getGrpcPort);
     registry.add("dapr.http.port", dapr::getHttpPort);
     registry.add("DAPR_HTTP_ENDPOINT", wireMock::getBaseUrl);
@@ -74,13 +80,7 @@ public class WebSocketBroadcastIT {
   void setSystemProperties() {
     System.setProperty("dapr.grpc.port", String.valueOf(dapr.getGrpcPort()));
     System.setProperty("dapr.http.port", String.valueOf(dapr.getHttpPort()));
-  }
-
-  @LocalServerPort private int port;
-
-  @BeforeEach
-  public void setUp() {
-    RestAssured.port = port;
+    RestAssured.port = APP_PORT;
   }
 
   @Test
@@ -90,7 +90,7 @@ public class WebSocketBroadcastIT {
 
     BlockingQueue<Map<String, Object>> received = new LinkedBlockingQueue<>();
 
-    String url = "ws://localhost:" + port + "/ws";
+    String url = "ws://localhost:" + APP_PORT + "/ws";
     StompSession session =
         stompClient
             .connectAsync(url, new StompSessionHandlerAdapter() {})

--- a/renovate.json
+++ b/renovate.json
@@ -39,7 +39,7 @@
   "prHourlyLimit": 0,
   "platformAutomerge": true,
   "automerge": true,
-  "automergeType": "branch",
+  "automergeType": "pr",
   "automergeStrategy": "squash",
   "ignoreTests": false,
   "vulnerabilityAlerts": {
@@ -81,6 +81,32 @@
       "groupName": "Spring Boot",
       "matchPackageNames": [
         "/^org\\.springframework\\.boot/"
+      ]
+    },
+    {
+      "description": "Group Spring Framework dependencies",
+      "groupName": "Spring Framework",
+      "matchPackageNames": [
+        "/^org\\.springframework:/"
+      ]
+    },
+    {
+      "description": "Group Apache commons dependencies",
+      "groupName": "Apache commons",
+      "matchPackageNames": [
+        "commons-io:commons-io",
+        "/^org\\.apache\\.commons/"
+      ]
+    },
+    {
+      "description": "Group annotation libraries",
+      "groupName": "annotations",
+      "matchPackageNames": [
+        "/^com\\.google\\.errorprone/",
+        "net.jcip:jcip-annotations",
+        "org.checkerframework:checker-qual",
+        "org.jetbrains:annotations",
+        "org.jspecify:jspecify"
       ]
     },
     {


### PR DESCRIPTION
## Summary

Applies the full output of `/project-review` plus the deferred follow-ups:
- **Phase A** (Makefile mise migration, Renovate, CI workflow paths-filter migration)
- **Phase B** (README + CLAUDE.md cleanup)
- **`/harden-image-pipeline` Phase 1+2** (smoke test + cosign signing on `publish-images`, matrix per service)
- **`/test-coverage-analysis` Phase 4** (5 hardcoded-port fixes + new `OrderCompletedStateIT`)

## Changes

| Area | Change |
|------|--------|
| `.mise.toml` | mise is now the single source of truth for `act`, `trivy`, `gitleaks`, `kind`, `kubectl`, `helm` |
| `Makefile` | Removed parallel-pinned `_VERSION` constants and `deps-act/-trivy/-gitleaks/-kind/-kubectl/-helm` targets; `MAVEN_VERSION` derived from `.mise.toml`; `coverage-check: coverage-generate`; `image-build` documents Paketo CNB self-containment; stale `mirror-images` removed from `.PHONY`; `ci-run` now passes a synthetic event payload so `dorny/paths-filter` resolves under act |
| `renovate.json` | `automergeType: "branch"` → `"pr"` (Rulesets-protected main was silently breaking automerge under "branch"); added Spring Framework, Apache commons, annotations grouping rules |
| `.github/workflows/ci.yml` | Completed paths-filter migration started in `b1cfaa4`: dropped trigger-level `paths-ignore`, added binary `code` flag to `changes` job, gated `static-check`/`build`/`test`/`integration-test` on it. Added `pull-requests: read` workflow permission. `cve-check` re-parented to `[static-check]`. Coverage gate no longer soft-fails. `ci-pass` now also fails on `cancelled`. Added `name:` to all `setup-java` steps. Refreshed `docker/login-action` SHA to v4.1.0. **`publish-images`**: converted to `strategy.matrix.service` (parallel per-service runners), added Spring Boot boot-marker smoke test gate, added cosign keyless OIDC signing post-push (`id-token: write` permission added) |
| `pizza-store/src/test/.../*.java` | 5 tests: `withAppPort(8080)` → `TestSocketUtils.findAvailableTcpPort()` per the canonical `pizza-kitchen` pattern. **New**: `OrderCompletedStateIT` covers the missing `ORDER_COMPLETED` branch of `receiveEvents` (state-store transition to `Status.completed`) |
| `README.md` | Removed 6 deleted `deps-*` rows from Make Targets. New `## API` section with endpoint table. Quarkus pointer + Resources moved after Contributing. "Runnable locally with Docker" rephrased to "run locally on KinD". H3 `### Deployment` → `### Deployment View` |
| `CLAUDE.md` | Removed `CLAUDE.md` self-reference row from Skills table; removed 6 deleted `deps-*` rows from Build & Test list |

## Deferred (out of scope for this PR)

- Multi-arch images: Paketo CNB `spring-boot:build-image` is single-arch by default; tracked in `CLAUDE.md` upgrade backlog
- Browser WS-bootstrap e2e (Playwright/puppeteer): tracked as a separate follow-up
- pizza-kitchen / pizza-delivery dedicated `*IT.java` classes: existing `*Test.java` classes already use Testcontainers + Dapr in-memory pubsub and cover the publish surface; adding parallel `*IT.java` would duplicate without new coverage

## Test plan

- [x] `actionlint .github/workflows/ci.yml` — clean
- [x] `make renovate-validate` — config validates
- [x] `make static-check` — format + checkstyle + trivy-fs + trivy-config + gitleaks + diagrams + mermaid all clean
- [x] `make test` — 4 unit tests in 51 s, all green
- [x] `make integration-test` — 6 ITs (was 5, +1 new) in 1 min 45 s, all green
- [x] `make build` + `make coverage-check` — ≥80% coverage all three modules
- [x] `make ci` — full local pipeline green
- [x] `make ci-run` — act-iterated `changes` + `static-check` + `build` + `test` + `integration-test` all green
- [x] Spring Boot boot-marker smoke test verified locally against `pizza-store:e2e`
- [ ] Real-CI run on push: `static-check`, `build`, `test`, `integration-test`, `cve-check` (tag-only, won't trigger here), `e2e` (path-filter sees Java + workflow changes), `publish-images` (tag-only, won't trigger here), `ci-pass`