### PR TITLE
test+ci: phase-4 test coverage gaps + multi-arch publish + ZAP baseline

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -323,6 +323,46 @@ jobs:
     - name: Run end-to-end tests
       run: make e2e
 
+    # DAST: ZAP baseline scan against the LB-exposed pizza-store. Runs only
+    # AFTER the assertion suite passes — keeps total e2e wall-clock predictable
+    # (ZAP baseline ~2 min) and avoids burning a full ZAP run on a broken
+    # cluster. Baseline scan is passive (no fuzzing, no destructive payloads),
+    # so safe to run against the live e2e LB. SARIF upload to the Security tab
+    # makes findings reviewable per-PR. continue-on-error: true keeps the e2e
+    # job from failing on advisory ZAP findings — promote to strict once the
+    # baseline is clean and a regression budget is set.
+    - name: Resolve LoadBalancer IP for ZAP scan
+      id: lb
+      run: |
+        IP=$(kubectl get svc pizza-store -o jsonpath='{.status.loadBalancer.ingress[0].ip}')
+        echo "url=http://${IP}/" >> "$GITHUB_OUTPUT"
+
+    - name: ZAP baseline scan
+      uses: zaproxy/action-baseline@2b5fc7f98d837319798ab7f128ea50b7d40563b6 # v0.14.0
+      continue-on-error: true
+      with:
+        target: ${{ steps.lb.outputs.url }}
+        # Standard baseline rules; cmd_options lets the action push a SARIF
+        # artifact upstream and a JSON report into the workflow run.
+        cmd_options: '-J zap-report.json -w zap-report.md'
+        fail_action: false
+        allow_issue_writing: false
+
+    - name: Upload ZAP baseline report
+      if: always()
+      uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+      continue-on-error: true
+      with:
+        name: zap-baseline-report
+        path: |
+          zap-report.json
+          zap-report.md
+          report_html.html
+          report_md.md
+          report_json.json
+        retention-days: 14
+        if-no-files-found: ignore
+
     - name: Collect diagnostics on failure
       if: failure()
       run: |
@@ -348,31 +388,34 @@ jobs:
   #   GATE 1: Trivy image scan (CRITICAL/HIGH blocking, fixed-only).
   #   GATE 2: Spring Boot boot-marker smoke test (catches boot regressions
   #           Trivy can't see — missing classes, port binds, config errors).
-  #   GATE 3: cosign keyless OIDC signing post-push (Sigstore Fulcio).
-  # provenance: false / sbom: false: not applicable to Paketo CNB build path
-  # (no buildkit attestations emitted), so the GHCR Packages "OS / Arch" tab
-  # already renders correctly.
-  # Multi-arch is single-arch (linux/amd64) for now — Paketo CNB
-  # spring-boot:build-image runs only on the host's native arch. ARM
-  # consumers (Apple Silicon, Graviton) need either a runs-on:
-  # ubuntu-24.04-arm matrix runner + manifest assemble, or a thin Dockerfile
-  # + docker/build-push-action. Tracked in CLAUDE.md upgrade backlog.
-  # strategy.matrix runs each service in parallel on its own runner —
-  # wall-clock = max(per-service-time), not sum.
+  #   GATE 3: per-arch push to GHCR with `:<version>-<arch>` tag suffix.
+  # The downstream `docker-manifest` job then assembles a multi-arch
+  # manifest list under `:<version>` + `:latest` and cosign-signs the
+  # manifest digest (single signature covers both archs).
+  #
+  # provenance: false / sbom: false applies to the Paketo CNB build path
+  # (no buildkit attestations emitted) so the GHCR Packages "OS / Arch" tab
+  # renders correctly. spring-boot:build-image only builds the host arch —
+  # cross-build is not supported — so amd64/arm64 each get a native runner.
   docker:
     needs: [static-check, build, test, integration-test, cve-check, e2e]
     if: startsWith(github.ref, 'refs/tags/v')
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.runner }}
     timeout-minutes: 30
     permissions:
       contents: read
       packages: write
-      id-token: write       # cosign keyless OIDC (Sigstore Fulcio)
     strategy:
       fail-fast: false      # one bad service shouldn't cancel the others'
-                            # in-flight scans/signs — collect all results
+                            # in-flight scans — collect all results
       matrix:
-        service: [pizza-store, pizza-kitchen, pizza-delivery]
+        include:
+          - { service: pizza-store,    arch: amd64, runner: ubuntu-latest      }
+          - { service: pizza-store,    arch: arm64, runner: ubuntu-24.04-arm   }
+          - { service: pizza-kitchen,  arch: amd64, runner: ubuntu-latest      }
+          - { service: pizza-kitchen,  arch: arm64, runner: ubuntu-24.04-arm   }
+          - { service: pizza-delivery, arch: amd64, runner: ubuntu-latest      }
+          - { service: pizza-delivery, arch: arm64, runner: ubuntu-24.04-arm   }
     env:
       REGISTRY: ghcr.io
 
@@ -411,12 +454,12 @@ jobs:
     # GATE 1+2: Build + Trivy image scan via existing make target.
     # SERVICES override scopes the loop to this matrix entry only — each
     # service builds + scans on its own runner in parallel. The matrix
-    # coordinate ($SVC) renders in the GitHub UI as `docker (pizza-store) /
-    # Build and scan image`, so the step name itself stays static.
+    # coordinate ($SVC) renders in the GitHub UI as `docker (pizza-store,
+    # amd64) / Build and scan image`, so the step name itself stays static.
     - name: Build and scan image
       run: make image-scan SERVICES='${{ matrix.service }}'
 
-    # GATE 3: Spring Boot boot-marker smoke test.
+    # GATE 3 of the per-arch flow: Spring Boot boot-marker smoke test.
     # Validates the image actually boots Spring Boot before publishing —
     # catches regressions Trivy and filesystem scans miss (missing classes,
     # port bind failures, broken auto-config). Pizza services depend on
@@ -455,8 +498,68 @@ jobs:
         username: ${{ github.actor }}
         password: ${{ secrets.GITHUB_TOKEN }}
 
-    - name: Build and push
-      id: push
+    - name: Push per-arch tag
+      env:
+        SVC: ${{ matrix.service }}
+        ARCH: ${{ matrix.arch }}
+        VERSION: ${{ steps.ver.outputs.version }}
+        OWNER: ${{ steps.ns.outputs.owner }}
+        REPO: ${{ steps.ns.outputs.repo }}
+      run: |
+        set -euo pipefail
+        # Repo-namespace (ghcr.io/<owner>/<repo>/<package>) — GITHUB_TOKEN
+        # can create new packages here on first push; user-namespace cannot.
+        src="${SVC}:e2e"
+        dst="${REGISTRY}/${OWNER}/${REPO}/${SVC}:${VERSION}-${ARCH}"
+        echo "--- ${src} → ${dst} ---"
+        docker tag "${src}" "${dst}"
+        docker push "${dst}"
+
+  # Assemble multi-arch manifest list per service and cosign-sign the
+  # manifest digest. Runs once after all per-arch pushes succeed. A single
+  # signature on the manifest covers every arch underneath — clearer Rekor
+  # trail than signing each per-arch image separately.
+  docker-manifest:
+    needs: docker
+    if: startsWith(github.ref, 'refs/tags/v')
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    permissions:
+      contents: read
+      packages: write
+      id-token: write       # cosign keyless OIDC (Sigstore Fulcio)
+    strategy:
+      fail-fast: false
+      matrix:
+        service: [pizza-store, pizza-kitchen, pizza-delivery]
+    env:
+      REGISTRY: ghcr.io
+
+    steps:
+    - name: Set up Docker Buildx
+      uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd # v4.0.0
+
+    - name: Set version from tag
+      id: ver
+      run: echo "version=${GITHUB_REF_NAME#v}" >> "$GITHUB_OUTPUT"
+
+    - name: Set lowercase image namespace
+      id: ns
+      run: |
+        OWNER=$(echo "${{ github.repository_owner }}" | tr '[:upper:]' '[:lower:]')
+        REPO=$(echo "${{ github.event.repository.name }}" | tr '[:upper:]' '[:lower:]')
+        echo "owner=${OWNER}" >> "$GITHUB_OUTPUT"
+        echo "repo=${REPO}" >> "$GITHUB_OUTPUT"
+
+    - name: Log in to GHCR
+      uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121 # v4.1.0
+      with:
+        registry: ${{ env.REGISTRY }}
+        username: ${{ github.actor }}
+        password: ${{ secrets.GITHUB_TOKEN }}
+
+    - name: Assemble multi-arch manifest
+      id: manifest
       env:
         SVC: ${{ matrix.service }}
         VERSION: ${{ steps.ver.outputs.version }}
@@ -464,28 +567,25 @@ jobs:
         REPO: ${{ steps.ns.outputs.repo }}
       run: |
         set -euo pipefail
-        # Use repo-namespace (ghcr.io/<owner>/<repo>/<package>) rather than
-        # user-namespace (ghcr.io/<owner>/<package>). GITHUB_TOKEN can CREATE
-        # new packages in the repo-namespace — GHCR auto-links them to this
-        # repo. In the user-namespace it cannot, resulting in
-        # `denied: permission_denied: write_package` on first push.
-        src="${SVC}:e2e"
-        dst_ver="${REGISTRY}/${OWNER}/${REPO}/${SVC}:${VERSION}"
-        dst_latest="${REGISTRY}/${OWNER}/${REPO}/${SVC}:latest"
-        echo "--- ${src} → ${dst_ver} + ${dst_latest} ---"
-        docker tag "${src}" "${dst_ver}"
-        docker tag "${src}" "${dst_latest}"
-        docker push "${dst_ver}"
-        docker push "${dst_latest}"
-        # Capture the manifest digest so cosign signs by digest, not by tag —
-        # the digest covers all tags pointing to it and produces a clearer
-        # Rekor trail than tag-based signing.
-        DIGEST=$(docker inspect --format '{{ index .RepoDigests 0 }}' "${dst_ver}" | sed 's/.*@//')
+        base="${REGISTRY}/${OWNER}/${REPO}/${SVC}"
+        amd64_ref="${base}:${VERSION}-amd64"
+        arm64_ref="${base}:${VERSION}-arm64"
+        ver_tag="${base}:${VERSION}"
+        latest_tag="${base}:latest"
+        # imagetools create stitches the per-arch refs into a manifest list
+        # and pushes both `:VERSION` and `:latest` pointing at the same
+        # digest. -t may be repeated to push multiple tags in one call.
+        docker buildx imagetools create \
+          -t "${ver_tag}" \
+          -t "${latest_tag}" \
+          "${amd64_ref}" \
+          "${arm64_ref}"
+        DIGEST=$(docker buildx imagetools inspect "${ver_tag}" --format '{{ .Manifest.Digest }}')
         echo "digest=${DIGEST}" >> "$GITHUB_OUTPUT"
         {
           echo 'tags<<TAGS_EOF'
-          echo "${dst_ver}"
-          echo "${dst_latest}"
+          echo "${ver_tag}"
+          echo "${latest_tag}"
           echo 'TAGS_EOF'
         } >> "$GITHUB_OUTPUT"
 
@@ -494,10 +594,11 @@ jobs:
 
     # Keyless OIDC signing via Sigstore Fulcio — no key material to manage,
     # signature provenance recorded in the public Rekor transparency log.
+    # Sign the manifest-list digest: a single signature covers both archs.
     - name: Sign image with cosign
       env:
-        TAGS: ${{ steps.push.outputs.tags }}
-        DIGEST: ${{ steps.push.outputs.digest }}
+        TAGS: ${{ steps.manifest.outputs.tags }}
+        DIGEST: ${{ steps.manifest.outputs.digest }}
       run: |
         set -euo pipefail
         while IFS= read -r tag; do
@@ -508,16 +609,16 @@ jobs:
 
   ci-pass:
     if: always()
-    needs: [changes, static-check, build, test, integration-test, cve-check, e2e, docker]
+    needs: [changes, static-check, build, test, integration-test, cve-check, e2e, docker, docker-manifest]
     timeout-minutes: 2
     runs-on: ubuntu-latest
     steps:
       - name: Verify all required jobs passed
         run: |
-          # docker is tag-gated; treat its 'skipped' result on non-tag runs
-          # as a pass. Code-gated jobs (static-check/build/test/IT) are also
-          # legitimately 'skipped' on docs-only PRs. Any 'failure' or
-          # 'cancelled' result fails the gate.
+          # docker + docker-manifest are tag-gated; treat their 'skipped'
+          # result on non-tag runs as a pass. Code-gated jobs
+          # (static-check/build/test/IT) are also legitimately 'skipped' on
+          # docs-only PRs. Any 'failure' or 'cancelled' result fails the gate.
           if [[ "${{ contains(needs.*.result, 'failure') }}" == "true" ]]; then
             echo "One or more required jobs failed"
             exit 1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -252,15 +252,11 @@ jobs:
         key: nvd-db-${{ hashFiles('pom.xml') }}
         restore-keys: nvd-db-
 
-    # Upstream bug: dependency-check 12.2.1's bundled open-vulnerability-client
-    # deserializer cannot parse the 9-digit nanosecond-precision timestamps the
-    # NVD API started returning ("Failed to deserialize java.time.ZonedDateTime
-    # ... unparsed text found at index 23"). Non-blocking until a fixed release
-    # ships upstream. HTML report still uploads when the step succeeds on a
-    # warm NVD cache. Track: dependency-check/DependencyCheck issues.
+    # dependency-check 12.2.2 (2026-05-03) ships the upstream fix for the
+    # NVD 9-digit nanosecond timestamp deserializer bug (PR #8427), so this
+    # step is back to strict — failures block the release flow as designed.
     - name: OWASP dependency check
       if: ${{ !env.ACT }}
-      continue-on-error: true
       env:
         NVD_API_KEY: ${{ secrets.NVD_API_KEY }}
       run: make cve-check
@@ -338,7 +334,7 @@ jobs:
         echo "url=http://${IP}/" >> "$GITHUB_OUTPUT"
 
     - name: ZAP baseline scan
-      uses: zaproxy/action-baseline@2b5fc7f98d837319798ab7f128ea50b7d40563b6 # v0.14.0
+      uses: zaproxy/action-baseline@6c5a007541891231cd9e0ddec25d4f25c59c9874 # v0.15.0
       continue-on-error: true
       with:
         target: ${{ steps.lb.outputs.url }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -95,10 +95,10 @@ jobs:
     - name: Install Maven
       run: make deps-maven
 
-    # mise provides trivy + gitleaks (pinned in .mise.toml) for the
-    # static-check composite gate (format-check, checkstyle, trivy-fs,
-    # trivy-config, secrets, diagrams-check, mermaid-lint). The act runner
-    # image has neither preinstalled.
+    # mise provides trivy, gitleaks, and kubeconform (pinned in .mise.toml)
+    # for the static-check composite gate (format-check, checkstyle, trivy-fs,
+    # trivy-config, secrets, diagrams-check, mermaid-lint, k8s-validate).
+    # The act runner image has none of them preinstalled.
     - name: Install mise
       uses: jdx/mise-action@1648a7812b9aeae629881980618f079932869151 # v4.0.1
       with:

--- a/.mise.toml
+++ b/.mise.toml
@@ -17,3 +17,15 @@ kind = "0.31.0"
 kubectl = "1.35.4"
 # renovate: datasource=github-releases depName=helm/helm
 helm = "4.1.4"
+# kubeconform validates k8s manifest YAML against vendored OpenAPI schemas
+# (no cluster needed). Used by `make k8s-validate` to gate every push on
+# both k8s/ and k8s-dapr-shared/ parsing cleanly.
+# renovate: datasource=github-releases depName=yannh/kubeconform
+kubeconform = "0.7.0"
+# websocat is a single-binary WebSocket client used by e2e/e2e-test.sh to
+# assert STOMP broadcast over the LB-exposed /ws endpoint (regression guard
+# for the PUBLIC_IP-hardcoded WebSocket bug retired 2026-04-26 — see
+# CLAUDE.md backlog). Installed via mise's cargo backend; first run on a
+# fresh host compiles from source (~1-2 min cached locally).
+# renovate: datasource=github-releases depName=vi/websocat
+"cargo:websocat" = "1.14.0"

--- a/.mise.toml
+++ b/.mise.toml
@@ -6,7 +6,7 @@ maven = "3.9.15"
 # renovate: datasource=node-version depName=node
 node = "22.22.2"
 # renovate: datasource=github-releases depName=nektos/act
-act = "0.2.87"
+act = "0.2.88"
 # renovate: datasource=github-releases depName=aquasecurity/trivy
 trivy = "0.70.0"
 # renovate: datasource=github-releases depName=gitleaks/gitleaks
@@ -24,8 +24,9 @@ helm = "4.1.4"
 kubeconform = "0.7.0"
 # websocat is a single-binary WebSocket client used by e2e/e2e-test.sh to
 # assert STOMP broadcast over the LB-exposed /ws endpoint (regression guard
-# for the PUBLIC_IP-hardcoded WebSocket bug retired 2026-04-26 — see
-# CLAUDE.md backlog). Installed via mise's cargo backend; first run on a
-# fresh host compiles from source (~1-2 min cached locally).
+# for the PUBLIC_IP-hardcoded WebSocket bug retired 2026-04-26). Installed
+# via mise's aqua backend — precompiled GitHub release binary (instant on
+# both fresh laptops and CI cold runners; the cargo: backend would compile
+# from source for ~1-2 min on cold cache).
 # renovate: datasource=github-releases depName=vi/websocat
-"cargo:websocat" = "1.14.0"
+"aqua:vi/websocat" = "1.14.1"

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -22,7 +22,8 @@ make trivy-config                       # Scan k8s/ and k8s-dapr-shared/ for KSV
 make secrets                            # Scan for leaked secrets (gitleaks)
 make deps-prune                         # Analyze Maven dependencies (advisory)
 make deps-prune-check                   # Fail if unused declared Maven dependencies exist
-make static-check                       # Composite: format-check + lint + trivy-fs + trivy-config + secrets + diagrams-check + mermaid-lint
+make static-check                       # Composite: format-check + lint + trivy-fs + trivy-config + secrets + diagrams-check + mermaid-lint + k8s-validate
+make k8s-validate                       # Validate k8s/ + k8s-dapr-shared/ manifests via kubeconform (vendored OpenAPI, no cluster)
 make diagrams                           # Render docs/diagrams/*.puml → docs/diagrams/out/*.png (PlantUML in Docker)
 make diagrams-clean                     # Remove rendered PNGs
 make diagrams-check                     # Verify committed PNGs match .puml sources (static-check gate)
@@ -162,6 +163,18 @@ Running multiple KinD clusters on the shared default `kind` Docker network cause
 - Workarounds: `kind delete cluster --name <other>` before `make e2e`, or use a per-cluster network via `KIND_EXPERIMENTAL_DOCKER_NETWORK`.
 - `make kind-destroy` prunes `kindccm-*` orphan Envoy sidecars left behind by `cloud-provider-kind`. Without that, a subsequent `kind-up` can land on an orphan's IP and inherit its stale Envoy config (pointed at dead pods from previous runs), producing "connection reset by peer" on the first curl.
 
+### Image publishing (multi-arch)
+
+- `docker` job is a per-service-per-arch matrix (6 runners): `{pizza-store, pizza-kitchen, pizza-delivery} × {amd64, arm64}`. arm64 runs on `ubuntu-24.04-arm` because Paketo CNB `spring-boot:build-image` builds only the host arch (no cross-build).
+- Each runner pushes its per-arch tag `ghcr.io/<owner>/<repo>/<svc>:<version>-<arch>`.
+- The downstream `docker-manifest` job assembles a multi-arch manifest list with `docker buildx imagetools create`, pushes both `:<version>` and `:latest` to GHCR, and signs the manifest digest with cosign keyless OIDC. A single signature covers both archs.
+
+### Test coverage extras
+
+- E2E asserts the WebSocket broadcast end-to-end via `websocat` (mise tool, `cargo:websocat 1.14.0`) — regression guard for the PUBLIC_IP-hardcoded bug retired 2026-04-26.
+- `make k8s-validate` (kubeconform) validates `k8s/` and `k8s-dapr-shared/` against vendored OpenAPI on every push, so drift in the unused alternate "shared sidecar" topology surfaces immediately.
+- `e2e` job runs an OWASP ZAP baseline DAST scan against the LB-exposed pizza-store after the assertion suite passes (`continue-on-error: true` while baseline budget is established).
+
 ## Upgrade Backlog
 
 Last reviewed: 2026-05-05
@@ -171,8 +184,6 @@ Last reviewed: 2026-05-05
 - [ ] **Alpha dependencies** — `opentelemetry-instrumentation-bom-alpha`, `wiremock-testcontainers` 1.0-alpha-15. Track GA releases.
 - [ ] **OWASP dependency-check NVD deserializer bug** — 12.2.1 cannot parse 9-digit nanosecond timestamps from the NVD API (`Failed to deserialize java.time.ZonedDateTime ... unparsed text found at index 23`). `cve-check` CI step is `continue-on-error: true` and `make pre-release` wraps it in `timeout 300` until a fixed release ships. Re-enable strict failure once upstream ships. Track: dependency-check/DependencyCheck.
 - [ ] **Single-app DaprContainer limitation** — upstream-blocked: `dapr/java-sdk:testcontainers-dapr/.../DaprContainer.java` exposes only single `appName/appPort/appChannelAddress` fields (no peer-app registration). Workaround in `KitchenInvocationIT` / `DeliveryInvocationIT`: override `DAPR_HTTP_ENDPOINT` to a WireMock receiver — verifies the emitted HTTP contract (verb, path, body) but bypasses the sidecar invoke hop. The full sidecar→app→sidecar path is covered by the KinD e2e via `make e2e`. Re-wire once upstream adds multi-app support.
-- [ ] **Multi-arch image publish (linux/arm64)** — `spring-boot:build-image` (Paketo CNB) builds only the host arch. Apple Silicon and Graviton consumers currently pull amd64 images. Path forward: add `runs-on: ubuntu-24.04-arm` matrix dimension with `docker manifest create`, OR migrate to a thin Dockerfile + `docker/build-push-action` with `platforms: linux/amd64,linux/arm64`.
-- [ ] **WebSocket assertion in e2e** — `WebSocketBroadcastIT` covers the WS path in-process, but `e2e/e2e-test.sh` does not connect a STOMP client to the LB-exposed `/ws`. The legacy `PUBLIC_IP`-hardcoded WebSocket bug surfaced 2026-04-26 because no e2e exercise this path. Add a `websocat` (in `.mise.toml`) or Playwright step subscribing to `/topic/events` during order placement.
 
 ## Skills
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -141,9 +141,9 @@ Permanent design rules and operational constraints. Each one is load-bearing —
 
 ### Release workflow
 
-- `make ci` deliberately omits `cve-check` and `image-scan` because both are slow and one is advisory. They run via `make pre-release` (auto-invoked by `make release`):
-  - `cve-check` is wrapped in `timeout 300` and `|| true`. The OWASP dependency-check plugin can spin 20+ min in an internal retry loop against the NVD deserializer bug without exiting non-zero, so the soft-fail `||` alone is not bounded. The HTML report uploads in CI when the warm NVD cache succeeds.
-  - `image-scan` is strict. It catches Paketo helper Go-stdlib CVEs that `trivy-fs` (workspace) and `cve-check` (Maven deps) both miss. `.trivyignore` documents currently-accepted Paketo-upstream CVEs with tracker URLs.
+- `make ci` deliberately omits `cve-check` and `image-scan` because both are slow. They run via `make pre-release` (auto-invoked by `make release`):
+  - Both gates are strict — the previous `timeout 300` + `|| true` workaround was removed when dependency-check 12.2.2 (2026-05-03) shipped the upstream fix for the NVD nanosecond-timestamp deserializer bug (PR #8427).
+  - `image-scan` catches Paketo helper Go-stdlib CVEs that `trivy-fs` (workspace) and `cve-check` (Maven deps) both miss. `.trivyignore` documents currently-accepted Paketo-upstream CVEs with tracker URLs.
 - `cve-check` also runs in CI on tag pushes, weekly cron (Mon 06:00 UTC), and `workflow_dispatch`.
 - The `cve-check` Make recipe routes `NVD_API_KEY` through `~/.m2/settings.xml` + `-DnvdApiServerId=nvd` (written via `printf` — bash builtin, no argv). The flag form `-DnvdApiKey=$$NVD_API_KEY` would leak the value via `ps -ef` / `/proc/<pid>/cmdline` for the entire ~30-min plugin lifetime.
 
@@ -177,13 +177,16 @@ Running multiple KinD clusters on the shared default `kind` Docker network cause
 
 ## Upgrade Backlog
 
-Last reviewed: 2026-05-05
+Last reviewed: 2026-05-05 (post `/upgrade-analysis` Wave 1 patches)
 
 - [ ] **Maven 4.0 migration** — plan when Maven 4.0 reaches GA (currently RC-5)
-- [ ] **Spring Boot 4.0 EOL (2026-12-31)** — monitor 4.1 release schedule, plan upgrade before Dec 2026
+- [ ] **Spring Boot 4.0 → 4.1 migration** — Spring Boot 4.0 OSS support ends **2026-12-31**. 4.1 GA is expected Q4 2026 (currently 4.1.0-RC1). Project commits to staying on the Spring Boot 4.x line; start the 4.0 → 4.1 migration plan ~Q3 2026 to land before EOL.
 - [ ] **Alpha dependencies** — `opentelemetry-instrumentation-bom-alpha`, `wiremock-testcontainers` 1.0-alpha-15. Track GA releases.
-- [ ] **OWASP dependency-check NVD deserializer bug** — 12.2.1 cannot parse 9-digit nanosecond timestamps from the NVD API (`Failed to deserialize java.time.ZonedDateTime ... unparsed text found at index 23`). `cve-check` CI step is `continue-on-error: true` and `make pre-release` wraps it in `timeout 300` until a fixed release ships. Re-enable strict failure once upstream ships. Track: dependency-check/DependencyCheck.
+- [ ] **`dapr-spring-boot-4-starter` 1.17.3 GA on Maven Central** — currently `1.17.3-rc-1` only. Bump `dapr.version` (and `testcontainers-dapr.version`, since they're the same property) when GA lands. Runtime is already on 1.17.5/1.17.6 — runtime-ahead-of-SDK is normal Dapr Java cadence.
+- [ ] **WireMock 4.0 GA** — currently `4.0.0-beta.10` upstream; project on stable `3.13.2`. Watch for 4.0 GA before bumping.
 - [ ] **Single-app DaprContainer limitation** — upstream-blocked: `dapr/java-sdk:testcontainers-dapr/.../DaprContainer.java` exposes only single `appName/appPort/appChannelAddress` fields (no peer-app registration). Workaround in `KitchenInvocationIT` / `DeliveryInvocationIT`: override `DAPR_HTTP_ENDPOINT` to a WireMock receiver — verifies the emitted HTTP contract (verb, path, body) but bypasses the sidecar invoke hop. The full sidecar→app→sidecar path is covered by the KinD e2e via `make e2e`. Re-wire once upstream adds multi-app support.
+- [ ] **kindest/node v1.36 + kubectl 1.36** — KinD 0.31.0 (2025-12-18) shipped node `v1.35.0`; next minor likely brings v1.36. Bump `kubectl` from 1.35.4 to 1.36.x only after the matching node image lands so cluster ↔ kubectl skew stays at +1 minor max.
+- [ ] **`zaproxy/action-baseline` v0.16+** — pinned to `v0.15.0` (2025-10-24). Bump after the first ZAP run produces a clean baseline so reports stay comparable across runs.
 
 ## Skills
 

--- a/Makefile
+++ b/Makefile
@@ -487,6 +487,37 @@ kind-deploy: kind-create image-build image-scan
 	done; \
 	echo "FAIL: pizza-store did not get a LoadBalancer IP"; exit 1
 
+#k8s-shared-deploy: @ Deploy alternate "shared sidecar" topology (k8s-dapr-shared/) to running cluster
+# Manual target — NOT wired into `make e2e` or CI. Use after `make kind-create`
+# to validate the alternate topology end-to-end. The pizza-store LoadBalancer
+# Service is the same shape as the default topology, so e2e/e2e-test.sh runs
+# against it unchanged. See k8s-dapr-shared/README.md for the topology rationale.
+k8s-shared-deploy: deps-check
+	@echo "--- Loading images into KinD cluster (if not present) ---"
+	@for svc in $(SERVICES); do \
+		kind load docker-image $$svc:$(E2E_IMAGE_TAG) --name $(KIND_CLUSTER_NAME) 2>&1 | tail -1; \
+	done
+	@echo "--- Deploying Redis (backs Dapr pubsub + state store) ---"
+	@$(KUBECTL) apply -f k8s/redis-e2e.yaml
+	@$(KUBECTL) rollout status deployment/redis --timeout=120s
+	@echo "--- Applying Dapr components (redis-backed) + subscriptions ---"
+	@$(KUBECTL) apply -f k8s/components-e2e.yaml
+	@$(KUBECTL) apply -f k8s/subscription.yaml
+	@echo "--- Applying shared-sidecar app manifests (with local image overrides) ---"
+	@sed -E "s|image: ghcr.io/andriykalashnykov/dapr-java/(pizza-(store|kitchen|delivery)):[^[:space:]]+|image: \\1:$(E2E_IMAGE_TAG)|g; \
+		s|imagePullPolicy: Always|imagePullPolicy: IfNotPresent|" \
+		k8s-dapr-shared/apps.yaml | $(KUBECTL) apply -f -
+	@echo "--- Patching pizza-store Service to LoadBalancer ---"
+	@$(KUBECTL) patch svc pizza-store -p '{"spec":{"type":"LoadBalancer"}}' 2>/dev/null || true
+	@echo "Shared-sidecar topology deployed. Validate with e2e/e2e-test.sh against the LoadBalancer IP."
+
+#k8s-shared-undeploy: @ Remove the alternate shared-sidecar topology from the cluster
+k8s-shared-undeploy: deps-check
+	@$(KUBECTL) delete -f k8s-dapr-shared/apps.yaml --ignore-not-found 2>/dev/null || true
+	@$(KUBECTL) delete -f k8s/subscription.yaml --ignore-not-found 2>/dev/null || true
+	@$(KUBECTL) delete -f k8s/components-e2e.yaml --ignore-not-found 2>/dev/null || true
+	@$(KUBECTL) delete -f k8s/redis-e2e.yaml --ignore-not-found 2>/dev/null || true
+
 #kind-undeploy: @ Remove app and Dapr components from KinD cluster
 kind-undeploy: deps-check
 	@for svc in $(SERVICES); do \
@@ -529,21 +560,13 @@ e2e: kind-up
 
 #pre-release: @ Run every slow gate that's NOT in `make ci` (cve-check + image-scan). Required before `make release`.
 pre-release:
-	@# cve-check is advisory pending the upstream NVD deserializer bug
-	@# (dependency-check/DependencyCheck issue, tracked in CLAUDE.md). Mirrors
-	@# the CI workflow's `continue-on-error: true` on the same step.
-	@#
-	@# Wrap in `timeout 300` to bound the hang: when the NVD API returns
-	@# 9-digit nanosecond timestamps the mvn dep-check plugin can spin in
-	@# an internal retry loop for 20+ min without exiting non-zero, which
-	@# means the `||` soft-fail never fires. Observed locally during the
-	@# first v0.1.0 `make release` — burned 22 min before SIGTERM. 300s is
-	@# enough for a warm NVD cache + API key, and short enough not to
-	@# block ship. When upstream fixes the deserializer, drop the wrapper.
-	@timeout 300 $(MAKE) cve-check || echo "WARN: cve-check failed or timed out after 5 min — see CLAUDE.md backlog (OWASP NVD deserializer bug). Continuing pre-release."
-	@# image-scan is the hard gate that caught Paketo CVEs post-push before.
+	@# cve-check + image-scan are both strict gates. dependency-check 12.2.2
+	@# (2026-05-03) ships the open-vulnerability-clients fix for the NVD
+	@# 9-digit nanosecond timestamp deserializer bug (PR #8427), so the
+	@# previous `timeout 300` + soft-fail wrapper is no longer needed.
+	@$(MAKE) cve-check
 	@$(MAKE) image-scan
-	@echo "Pre-release gates passed (image-scan strict, cve-check advisory)."
+	@echo "Pre-release gates passed."
 
 #release: @ Create a release tag with semver validation (usage: make release VERSION=x.y.z)
 #          Runs `pre-release` first so a failing OWASP or image scan blocks the
@@ -569,4 +592,5 @@ release: pre-release
 	print-deps-updates update-deps renovate-validate \
 	image-build image-scan kind-create kind-deploy kind-undeploy kind-destroy \
 	kind-up kind-down e2e pre-release release \
-	diagrams diagrams-clean diagrams-check mermaid-lint k8s-validate
+	diagrams diagrams-clean diagrams-check mermaid-lint k8s-validate \
+	k8s-shared-deploy k8s-shared-undeploy

--- a/Makefile
+++ b/Makefile
@@ -181,6 +181,19 @@ trivy-config:
 	@trivy config --severity HIGH,CRITICAL --exit-code 1 k8s/
 	@trivy config --severity HIGH,CRITICAL --exit-code 1 k8s-dapr-shared/
 
+#k8s-validate: @ Validate k8s/ and k8s-dapr-shared/ manifests against vendored OpenAPI (kubeconform)
+# k8s-dapr-shared is an alternate "shared sidecar" topology that is NOT
+# exercised by `make e2e`. Without this gate, drift between the two manifest
+# trees ships silently and only surfaces on a manual `kubectl apply -f
+# k8s-dapr-shared/`. kubeconform validates against vendored OpenAPI schemas,
+# so no cluster is required — wires cleanly into static-check on every push.
+# -ignore-missing-schemas tolerates Dapr CRDs (Component, Subscription)
+# whose schemas aren't in the upstream master-standalone bundle.
+k8s-validate:
+	@command -v kubeconform >/dev/null 2>&1 || { echo "Error: kubeconform is required (run 'mise install')."; exit 1; }
+	@kubeconform -strict -ignore-missing-schemas -summary k8s/
+	@kubeconform -strict -ignore-missing-schemas -summary k8s-dapr-shared/
+
 #secrets: @ Scan for leaked secrets with gitleaks
 secrets:
 	@gitleaks detect --source . --verbose --redact
@@ -242,8 +255,8 @@ mermaid-lint:
 			> /dev/null || { echo "FAIL: Mermaid lint failed in $$f"; exit 1; }; \
 	done
 
-#static-check: @ Composite quality gate (format-check + lint + trivy-fs + trivy-config + secrets + diagrams-check + mermaid-lint)
-static-check: format-check lint trivy-fs trivy-config secrets diagrams-check mermaid-lint
+#static-check: @ Composite quality gate (format-check + lint + trivy-fs + trivy-config + secrets + diagrams-check + mermaid-lint + k8s-validate)
+static-check: format-check lint trivy-fs trivy-config secrets diagrams-check mermaid-lint k8s-validate
 	@echo "All static checks passed"
 
 #run: @ Run the application
@@ -556,4 +569,4 @@ release: pre-release
 	print-deps-updates update-deps renovate-validate \
 	image-build image-scan kind-create kind-deploy kind-undeploy kind-destroy \
 	kind-up kind-down e2e pre-release release \
-	diagrams diagrams-clean diagrams-check mermaid-lint
+	diagrams diagrams-clean diagrams-check mermaid-lint k8s-validate

--- a/README.md
+++ b/README.md
@@ -38,6 +38,7 @@ C4Context
 | Testcontainers | Testcontainers 2.x + `testcontainers-dapr` 1.17.2 | Runs containerized Dapr sidecars during tests |
 | Code quality | Checkstyle + google-java-format 1.35.0 + Trivy + gitleaks | Composite `make static-check` gate |
 | Diagram lint | PlantUML 1.2026.2 (`make diagrams-check`) + mermaid-cli 11.12.0 (`make mermaid-lint`) | Wired into `make static-check` |
+| Manifest validation | kubeconform 0.7.0 (`make k8s-validate`, vendored OpenAPI — no cluster needed) | Validates both `k8s/` and `k8s-dapr-shared/` on every push |
 | Coverage | JaCoCo (80% min, enforced) | Enforced by `make coverage-check` |
 | Version manager | [mise](https://mise.jdx.dev/) | Pins Java/Maven/Node via `.mise.toml` |
 | CI | GitHub Actions | Workflow at `.github/workflows/ci.yml` |
@@ -284,7 +285,8 @@ Run `make help` to see all available targets.
 
 | Target | Description |
 |--------|-------------|
-| `make static-check` | Composite gate: `format-check` + `lint` + `trivy-fs` + `trivy-config` + `secrets` + `diagrams-check` + `mermaid-lint` |
+| `make static-check` | Composite gate: `format-check` + `lint` + `trivy-fs` + `trivy-config` + `secrets` + `diagrams-check` + `mermaid-lint` + `k8s-validate` |
+| `make k8s-validate` | Validate `k8s/` + `k8s-dapr-shared/` manifests against vendored OpenAPI via kubeconform (no cluster needed) |
 | `make lint` | Run Checkstyle static analysis |
 | `make format` | Auto-format Java source (google-java-format) |
 | `make format-check` | Verify source formatting without modifying files |
@@ -357,22 +359,25 @@ GitHub Actions runs on push to `main`, tags `v*`, pull requests, a weekly schedu
 | Job | Triggers | Depends on | Steps |
 |-----|----------|-----------|-------|
 | **changes** | push, PR, tags | — | `dorny/paths-filter` emits `code` (binary skip-everything-on-docs-only) and `e2e` (heavy KinD job gating) flags consumed by downstream jobs |
-| **static-check** | push, PR, tags (`code` flag) | `changes` | `make static-check` (format-check, Checkstyle, trivy-fs, trivy-config, gitleaks, diagrams-check, mermaid-lint); `fetch-depth: 0` so gitleaks can walk history |
+| **static-check** | push, PR, tags (`code` flag) | `changes` | `make static-check` (format-check, Checkstyle, trivy-fs, trivy-config, gitleaks, diagrams-check, mermaid-lint, k8s-validate); `fetch-depth: 0` so gitleaks can walk history |
 | **build** | push, PR, tags (`code` flag) | `changes`, `static-check` | `make build`; tag-gated artifact upload of `pizza-*/target/*.jar` |
 | **test** | push, PR, tags (`code` flag) | `changes`, `static-check` | `make test` (Surefire unit tests only — fast feedback) |
 | **integration-test** | push, PR, tags (`code` flag) | `changes`, `static-check` | `make coverage-generate` + `make coverage-check`; runs surefire + failsafe + merged-coverage gate; uploads JaCoCo report |
 | **cve-check** | tag push, weekly cron (Mon 06:00 UTC), `workflow_dispatch` | `static-check` | `make cve-check` (OWASP dependency-check), NVD cache, HTML report upload; `continue-on-error` until upstream NVD deserializer fix |
-| **e2e** | push to `main`/tag, PR label `run-e2e` or `e2e` flag, `workflow_dispatch` | `changes`, `build`, `test` | `jdx/mise-action` installs kind/kubectl/helm/trivy/gitleaks via `mise`, then `make e2e`; collects pod logs + cluster events on failure |
-| **docker** | tag push only | `static-check`, `build`, `test`, `integration-test`, `cve-check`, `e2e` | Per-service matrix (parallel runner per `pizza-store` / `pizza-kitchen` / `pizza-delivery`). GATE 1+2: `make image-scan` builds via `spring-boot:build-image` (Paketo CNB) and runs `trivy image --severity HIGH,CRITICAL --ignore-unfixed --exit-code 1`. GATE 3: Spring Boot boot-marker smoke test (90 s timeout, fails on missing classes / port-bind / broken auto-config). Then push to `ghcr.io/<owner>/<repo>/pizza-*:<version>` + `:latest`, capture digest from `RepoDigests`, and sign with [cosign keyless OIDC](https://docs.sigstore.dev/cosign/keyless/) (Sigstore Fulcio, no key material to manage; signature recorded in the public Rekor transparency log) |
+| **e2e** | push to `main`/tag, PR label `run-e2e` or `e2e` flag, `workflow_dispatch` | `changes`, `build`, `test` | `jdx/mise-action` installs kind/kubectl/helm/trivy/gitleaks/kubeconform/websocat via `mise`, then `make e2e` (now includes K1.5 route-readiness poll + WebSocket broadcast assertion via `websocat`); followed by an OWASP ZAP baseline DAST scan against the LB-exposed pizza-store. Collects pod logs + cluster events on failure |
+| **docker** | tag push only | `static-check`, `build`, `test`, `integration-test`, `cve-check`, `e2e` | Per-service-per-arch matrix (6 runners total: `{pizza-store, pizza-kitchen, pizza-delivery} × {amd64, arm64}`; arm64 runs on `ubuntu-24.04-arm`). GATE 1+2: `make image-scan` builds via `spring-boot:build-image` (Paketo CNB, native arch only) and runs `trivy image --severity HIGH,CRITICAL --ignore-unfixed --exit-code 1`. GATE 3: Spring Boot boot-marker smoke test (90 s timeout, fails on missing classes / port-bind / broken auto-config). Each runner pushes its per-arch tag `ghcr.io/<owner>/<repo>/pizza-*:<version>-<arch>` |
+| **docker-manifest** | tag push only | `docker` | Per-service matrix. Assembles a multi-arch manifest list with `docker buildx imagetools create` from the per-arch refs, pushes both `:<version>` and `:latest` to GHCR, and signs the manifest digest with [cosign keyless OIDC](https://docs.sigstore.dev/cosign/keyless/) (Sigstore Fulcio, no key material to manage; one signature covers both archs and is recorded in the public Rekor transparency log) |
 | **ci-pass** | always | all above | Gate job that fails if any needed job failed or was cancelled (required-status-check target) |
 
-Verify a published image's signature locally:
+Verify a published multi-arch image's signature locally:
 
 ```bash
 cosign verify ghcr.io/andriykalashnykov/dapr-java/pizza-store:0.1.2 \
   --certificate-identity-regexp 'https://github.com/AndriyKalashnykov/dapr-java/.github/workflows/ci.yml@refs/tags/v.*' \
   --certificate-oidc-issuer https://token.actions.githubusercontent.com
 ```
+
+The manifest digest is shared by `linux/amd64` and `linux/arm64` — a single signature covers both. Inspect with `docker buildx imagetools inspect ghcr.io/andriykalashnykov/dapr-java/pizza-store:0.1.2`.
 
 ### Required Secrets and Variables
 

--- a/README.md
+++ b/README.md
@@ -31,9 +31,9 @@ C4Context
 | Framework | Spring Boot 4.0.6 | Current GA; provides embedded Tomcat, auto-configuration, and Actuator |
 | Runtime sidecar | Dapr 1.17.5 (Helm) / 1.17.2 (Testcontainers) | Provides PubSub, State Store, Service Invocation APIs. Helm chart on KinD/prod runs ahead of the Java SDK; Testcontainers pins to the SDK version |
 | Dapr SDK | `dapr-spring-boot-4-starter` 1.17.2 | Latest stable on Maven Central; 1.17.3 is RC-only |
-| HTTP server | Embedded Tomcat 11.0.21 | Pinned in `dependencyManagement` to address CVEs |
-| JSON | Jackson 3.1.2 | Pinned to address CVE-reported 2.x transitive dependencies |
-| gRPC | gRPC 1.80.0 | Pinned to address CVEs in older Spring-Boot-managed version |
+| HTTP server | Embedded Tomcat 11.0.22 | Pinned in `dependencyManagement` to address CVEs |
+| JSON | Jackson 3.1.3 | Pinned to address CVE-reported 2.x transitive dependencies |
+| gRPC | gRPC 1.81.0 | Pinned to address CVEs in older Spring-Boot-managed version |
 | Build | Maven 3.9.15 | Latest 3.9.x; Maven 4.0 upgrade tracked in backlog |
 | Testcontainers | Testcontainers 2.x + `testcontainers-dapr` 1.17.2 | Runs containerized Dapr sidecars during tests |
 | Code quality | Checkstyle + google-java-format 1.35.0 + Trivy + gitleaks | Composite `make static-check` gate |
@@ -322,6 +322,8 @@ Run `make help` to see all available targets.
 | `make kind-deploy` | (granular) Build + load images, apply manifests, wait for rollout + LB IP |
 | `make kind-undeploy` | (granular) Delete application manifests from the cluster |
 | `make kind-destroy` | (granular) Stop cloud-provider-kind + delete KinD cluster |
+| `make k8s-shared-deploy` | Deploy the alternate "shared sidecar" topology (`k8s-dapr-shared/`) — manual, not in CI. See [`k8s-dapr-shared/README.md`](k8s-dapr-shared/README.md) |
+| `make k8s-shared-undeploy` | Remove the shared-sidecar topology |
 
 ### CI
 

--- a/e2e/e2e-test.sh
+++ b/e2e/e2e-test.sh
@@ -201,7 +201,55 @@ echo ""
 echo "=== Negative case ==="
 assert_status_in_range POST "$BASE/order" 400 499 'this is not json'
 
-# 6. OTel traceparent propagation (optional, soft check)
+# 6. WebSocket broadcast assertion (regression guard for the
+# PUBLIC_IP-hardcoded WS bug retired 2026-04-26). Subscribes a STOMP client
+# to /topic/events through the LB-exposed /ws endpoint, places a fresh
+# order, and asserts at least one MESSAGE frame arrives. Skipped when
+# `websocat` isn't on PATH (mise installs `cargo:websocat`; bare hosts
+# without mise won't have it — soft-skip rather than fail to keep the
+# script portable across local debugging contexts).
+echo ""
+echo "=== WebSocket broadcast assertion ==="
+if ! command -v websocat >/dev/null 2>&1; then
+  echo "SKIP: websocat not on PATH (run 'mise install' to provision it). Add 'cargo:websocat' is in .mise.toml."
+else
+  WS_LOG=$(mktemp)
+  # STOMP CONNECT then SUBSCRIBE; sleep keeps the connection open while the
+  # order placement triggers a broadcast. \x00 is the STOMP frame terminator.
+  {
+    printf 'CONNECT\naccept-version:1.2\nhost:%s\n\n\x00\n' "$GATEWAY_IP"
+    printf 'SUBSCRIBE\nid:sub-e2e\ndestination:/topic/events\n\n\x00\n'
+    sleep 25
+  } | websocat "ws://${GATEWAY_IP}:${GATEWAY_PORT}/ws" > "$WS_LOG" 2>&1 &
+  WS_PID=$!
+  sleep 1  # Let CONNECT/SUBSCRIBE land before triggering the broadcast.
+
+  WS_ORDER='{"customer":{"name":"ws-tester","email":"ws@example.com"},"items":[{"type":"margherita","amount":1}]}'
+  curl -sf --max-time 15 -H 'Content-Type: application/json' \
+    -d "$WS_ORDER" "$BASE/order" >/dev/null || true
+
+  # Wait up to 25s for at least one STOMP MESSAGE frame.
+  ws_seen=0
+  for _ in $(seq 1 25); do
+    if grep -q '^MESSAGE' "$WS_LOG" 2>/dev/null; then
+      ws_seen=1
+      break
+    fi
+    sleep 1
+  done
+
+  kill "$WS_PID" 2>/dev/null || true
+  wait "$WS_PID" 2>/dev/null || true
+
+  if (( ws_seen == 1 )); then
+    pass "WS broadcast received during order placement (regression guard for PUBLIC_IP/WS-URL bugs)"
+  else
+    fail "WS broadcast NOT received during order placement (last 30 lines of capture: $(tail -30 "$WS_LOG"))"
+  fi
+  rm -f "$WS_LOG"
+fi
+
+# 7. OTel traceparent propagation (optional, soft check)
 echo ""
 echo "=== OTel traceparent (optional) ==="
 HDRS=$(curl -s -D - -o /dev/null --max-time 10 "$BASE/actuator/health" || true)

--- a/k8s-dapr-shared/README.md
+++ b/k8s-dapr-shared/README.md
@@ -1,0 +1,30 @@
+# `k8s-dapr-shared/` — alternate "shared sidecar" deployment topology
+
+This directory holds an **alternate Kubernetes deployment topology** that runs the three pizza services against centralized Dapr sidecars rather than the per-pod injector model used by [`k8s/`](../k8s/).
+
+## How it differs from `k8s/`
+
+| Aspect | `k8s/` (default) | `k8s-dapr-shared/` (alternate) |
+|---|---|---|
+| Dapr sidecar | One per pod, injected via `dapr.io/enabled: "true"` annotation | Standalone `Deployment`s — one per app-id (`pizza-store-dapr`, `kitchen-service-dapr`, `delivery-service-dapr`) — each fronted by its own ClusterIP `Service` |
+| Sidecar count for 3 replicas of all 3 services | 9 sidecars (one per pod) | 3 sidecars total (one per app-id) |
+| App → Dapr endpoint | `localhost:3500` (in-pod) | `http://<app-id>-dapr.default.svc.cluster.local:3500` (cross-pod via Service VIP) |
+| Pod-level Dapr annotations | `dapr.io/app-id`, `dapr.io/app-port`, `dapr.io/enabled` | All commented out — apps reach Dapr via `DAPR_HTTP_ENDPOINT` / `DAPR_GRPC_ENDPOINT` env vars instead |
+| mTLS between app and sidecar | In-pod loopback (no TLS needed) | Cross-pod — depends on cluster network policies + Dapr mTLS config |
+
+The shared-sidecar topology trades isolation (a misbehaving sidecar affects every replica that talks to it) for lower memory overhead at scale (saves ~50MB per "extra" sidecar that would otherwise have been injected). It is most useful when a workload has many small replicas of the same app-id and the sidecar's resource footprint dominates the pod's footprint.
+
+## Operational status
+
+- **CI coverage**: `make k8s-validate` (kubeconform) parses these manifests on every push, so YAML / schema drift is caught immediately.
+- **E2E coverage**: `make e2e` exercises the **default** `k8s/` topology only. The shared-sidecar topology is **not** asserted end-to-end in CI — wall-clock cost of running both topologies on every push isn't justified for a reference-implementation project.
+- **Manual validation**: use `make k8s-shared-deploy` (defined in the root [`Makefile`](../Makefile)) to deploy this topology against a running KinD cluster created via `make kind-create`. The application URL surfaces via the same `pizza-store` LoadBalancer Service the default topology uses, so the existing `e2e/e2e-test.sh` script works against it too.
+
+## When to choose this topology
+
+| Pick | Topology |
+|---|---|
+| You want simplicity, one sidecar per pod, full app↔sidecar isolation, and the lowest blast radius per failure | `k8s/` (default) |
+| You want fewer total Dapr processes, are comfortable with the cross-pod hop, and your mTLS / network policy story is mature | `k8s-dapr-shared/` |
+
+For new deployments, the default `k8s/` topology is the recommended starting point.

--- a/k8s-dapr-shared/apps.yaml
+++ b/k8s-dapr-shared/apps.yaml
@@ -201,6 +201,10 @@ spec:
           value: http://pizza-store-dapr.default.svc.cluster.local:50001
         - name: STATE_STORE_NAME
           value: kvstore
+        # Maps to Spring placeholder ${cors.allowed-origins} read by @CrossOrigin
+        # in PizzaStore.java. Override per-environment.
+        - name: CORS_ALLOWED_ORIGINS
+          value: "http://localhost:5173"
         livenessProbe:
           httpGet:
             path: /actuator/health

--- a/k8s/pizza-store.yaml
+++ b/k8s/pizza-store.yaml
@@ -35,6 +35,11 @@ spec:
           value: "-XX:+UseParallelGC -XX:ActiveProcessorCount=1 -XX:MaxRAMPercentage=75 -XX:TieredStopAtLevel=1"
         - name: STATE_STORE_NAME
           value: kvstore
+        # Maps to Spring placeholder ${cors.allowed-origins} read by @CrossOrigin
+        # in PizzaStore.java. Override per-environment via the manifest; the
+        # localhost:5173 default in source is the dev fallback only.
+        - name: CORS_ALLOWED_ORIGINS
+          value: "http://localhost:5173"
         livenessProbe:
           httpGet:
             path: /actuator/health

--- a/pizza-delivery/src/test/java/io/diagrid/dapr/PizzaDeliveryTest.java
+++ b/pizza-delivery/src/test/java/io/diagrid/dapr/PizzaDeliveryTest.java
@@ -121,4 +121,20 @@ public class PizzaDeliveryTest {
         completed.getData().service(),
         "Completed event should be attributed to the delivery service");
   }
+
+  // Malformed JSON body to PUT /deliver must be rejected with 400 by Spring's
+  // HttpMessageNotReadable handler before the controller runs. Catches
+  // regressions where a permissive @RequestBody validator (or a custom
+  // ExceptionHandler that swallows parse errors) lets garbage through.
+  @Test
+  public void testDeliveryRejectsMalformedBody() {
+    with()
+        .body("this is not json")
+        .contentType(ContentType.JSON)
+        .when()
+        .request("PUT", "/deliver")
+        .then()
+        .assertThat()
+        .statusCode(400);
+  }
 }

--- a/pizza-kitchen/src/test/java/io/diagrid/dapr/PizzaKitchenTest.java
+++ b/pizza-kitchen/src/test/java/io/diagrid/dapr/PizzaKitchenTest.java
@@ -113,4 +113,20 @@ public class PizzaKitchenTest {
         ready.getData().order().id(),
         "Ready event payload should preserve the submitted order id");
   }
+
+  // Malformed JSON body to PUT /prepare must be rejected with 400 by Spring's
+  // HttpMessageNotReadable handler before the controller runs. Catches
+  // regressions where a permissive @RequestBody validator (or a custom
+  // ExceptionHandler that swallows parse errors) lets garbage through.
+  @Test
+  public void testPrepareRejectsMalformedBody() {
+    with()
+        .body("this is not json")
+        .contentType(ContentType.JSON)
+        .when()
+        .request("PUT", "/prepare")
+        .then()
+        .assertThat()
+        .statusCode(400);
+  }
 }

--- a/pizza-store/src/main/java/io/diagrid/dapr/PizzaStore.java
+++ b/pizza-store/src/main/java/io/diagrid/dapr/PizzaStore.java
@@ -28,7 +28,7 @@ import org.springframework.web.client.RestTemplate;
 
 @SpringBootApplication
 @RestController
-@CrossOrigin(origins = "http://localhost:5173", maxAge = 3600)
+@CrossOrigin(origins = "${cors.allowed-origins:http://localhost:5173}", maxAge = 3600)
 public class PizzaStore {
 
   @Value("${DAPR_HTTP_ENDPOINT:http://localhost:3500}")

--- a/pizza-store/src/test/java/io/diagrid/dapr/OrderJsonTest.java
+++ b/pizza-store/src/test/java/io/diagrid/dapr/OrderJsonTest.java
@@ -1,0 +1,175 @@
+package io.diagrid.dapr;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import io.diagrid.dapr.PizzaStore.Customer;
+import io.diagrid.dapr.PizzaStore.Order;
+import io.diagrid.dapr.PizzaStore.OrderItem;
+import io.diagrid.dapr.PizzaStore.PizzaType;
+import io.diagrid.dapr.PizzaStore.Status;
+import java.util.Date;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+import tools.jackson.databind.ObjectMapper;
+
+/**
+ * Pure-Jackson round-trip tests for the Order record.
+ *
+ * <p>Defaulting lives inside the {@code @JsonCreator} constructor — null id triggers a UUID, null
+ * orderDate triggers `new Date()`, null status defaults to {@code Status.created}. These branches
+ * are otherwise only exercised end-to-end through the controller, which makes a regression in the
+ * default values invisible to the existing tests. This test class has no Dapr / Spring container —
+ * runs in milliseconds, no Docker required.
+ */
+public class OrderJsonTest {
+
+  // Jackson 3 ObjectMapper. Default StdDateFormat handles ISO-8601 strings on
+  // read, defaults to epoch ms on write — both fine for the round-trip test
+  // since assertions compare Date.getTime() rather than the wire format.
+  private final ObjectMapper mapper = new ObjectMapper();
+
+  @Test
+  public void deserializesOrderWithAllFieldsExplicit() throws Exception {
+    String json =
+        """
+        {
+            "id": "explicit-1",
+            "customer": {"name": "alice", "email": "alice@example.com"},
+            "items": [{"type": "pepperoni", "amount": 2}],
+            "orderDate": "2024-01-15T10:30:00.000+00:00",
+            "status": "completed"
+        }
+        """;
+
+    Order order = mapper.readValue(json, Order.class);
+
+    assertEquals("explicit-1", order.id(), "Explicit id must be preserved");
+    assertEquals("alice", order.customer().name());
+    assertEquals(1, order.items().size());
+    assertEquals(PizzaType.pepperoni, order.items().get(0).type());
+    assertEquals(2, order.items().get(0).amount());
+    assertNotNull(order.orderDate(), "Explicit orderDate must be preserved");
+    assertEquals(Status.completed, order.status(), "Explicit status must be preserved");
+  }
+
+  @Test
+  public void appliesIdDefaultWhenMissing() throws Exception {
+    String json =
+        """
+        {
+            "customer": {"name": "bob", "email": "bob@example.com"},
+            "items": [{"type": "margherita", "amount": 1}],
+            "orderDate": "2024-01-15T10:30:00.000+00:00",
+            "status": "created"
+        }
+        """;
+
+    Order order = mapper.readValue(json, Order.class);
+
+    assertNotNull(order.id(), "Missing id must be defaulted to a fresh UUID");
+    // UUIDs are 36 chars (8-4-4-4-12 hex with dashes).
+    assertEquals(36, order.id().length(), "Defaulted id must look like a UUID");
+    assertTrue(order.id().contains("-"), "Defaulted id must look like a UUID");
+  }
+
+  @Test
+  public void appliesOrderDateDefaultWhenMissing() throws Exception {
+    String json =
+        """
+        {
+            "id": "no-date-1",
+            "customer": {"name": "c", "email": "c@c"},
+            "items": [{"type": "margherita", "amount": 1}],
+            "status": "created"
+        }
+        """;
+
+    long before = System.currentTimeMillis();
+    Order order = mapper.readValue(json, Order.class);
+    long after = System.currentTimeMillis();
+
+    assertNotNull(order.orderDate(), "Missing orderDate must be defaulted to now");
+    long ts = order.orderDate().getTime();
+    assertTrue(
+        ts >= before && ts <= after,
+        "Defaulted orderDate must fall within the deserialization window (was " + ts + ")");
+  }
+
+  @Test
+  public void appliesStatusDefaultWhenMissing() throws Exception {
+    String json =
+        """
+        {
+            "id": "no-status-1",
+            "customer": {"name": "d", "email": "d@d"},
+            "items": [{"type": "vegetarian", "amount": 1}],
+            "orderDate": "2024-01-15T10:30:00.000+00:00"
+        }
+        """;
+
+    Order order = mapper.readValue(json, Order.class);
+
+    assertEquals(Status.created, order.status(), "Missing status must default to created");
+  }
+
+  @Test
+  public void serializesAndDeserializesRoundTrip() throws Exception {
+    Order original =
+        new Order(
+            new Customer("eve", "eve@example.com"),
+            List.of(new OrderItem(PizzaType.hawaiian, 3)),
+            new Date(1_700_000_000_000L),
+            Status.delivery);
+
+    String json = mapper.writeValueAsString(original);
+    Order roundTripped = mapper.readValue(json, Order.class);
+
+    assertEquals(original.id(), roundTripped.id());
+    assertEquals(original.customer(), roundTripped.customer());
+    assertEquals(original.items(), roundTripped.items());
+    assertEquals(original.status(), roundTripped.status());
+    assertEquals(
+        original.orderDate().getTime(),
+        roundTripped.orderDate().getTime(),
+        "Round-trip must preserve orderDate to millisecond precision");
+  }
+
+  @Test
+  public void copyConstructorPreservesAllFields() {
+    Order original =
+        new Order(
+            new Customer("frank", "frank@example.com"),
+            List.of(new OrderItem(PizzaType.pepperoni, 2)),
+            new Date(1_700_000_000_000L),
+            Status.delivery);
+
+    Order copy = new Order(original);
+
+    assertEquals(original.id(), copy.id(), "Copy must preserve id (NOT generate a new one)");
+    assertEquals(original.customer(), copy.customer());
+    assertEquals(original.items(), copy.items());
+    assertEquals(original.orderDate(), copy.orderDate());
+    assertEquals(original.status(), copy.status());
+  }
+
+  @Test
+  public void twoOrdersWithoutExplicitIdsGetDifferentDefaults() throws Exception {
+    String json =
+        """
+        {
+            "customer": {"name": "g", "email": "g@g"},
+            "items": [{"type": "margherita", "amount": 1}],
+            "orderDate": "2024-01-15T10:30:00.000+00:00",
+            "status": "created"
+        }
+        """;
+
+    Order a = mapper.readValue(json, Order.class);
+    Order b = mapper.readValue(json, Order.class);
+
+    assertNotEquals(a.id(), b.id(), "Each defaulted id must be a fresh UUID");
+  }
+}

--- a/pizza-store/src/test/java/io/diagrid/dapr/PizzaStoreStateStoreIT.java
+++ b/pizza-store/src/test/java/io/diagrid/dapr/PizzaStoreStateStoreIT.java
@@ -19,7 +19,9 @@ import java.time.Duration;
 import java.util.Arrays;
 import java.util.Collections;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.MethodOrderer;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestMethodOrder;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.testcontainers.context.ImportTestcontainers;
 import org.springframework.test.context.DynamicPropertyRegistry;
@@ -37,6 +39,7 @@ import org.wiremock.integrations.testcontainers.WireMockContainer;
     classes = PizzaStoreAppTest.class,
     webEnvironment = SpringBootTest.WebEnvironment.DEFINED_PORT)
 @ImportTestcontainers
+@TestMethodOrder(MethodOrderer.OrderAnnotation.class)
 public class PizzaStoreStateStoreIT {
 
   // Allocate a free port at class-load time so DaprContainer's app channel
@@ -74,6 +77,7 @@ public class PizzaStoreStateStoreIT {
   }
 
   @Test
+  @org.junit.jupiter.api.Order(3)
   public void storesAndRetrievesOrder() {
     Order submitted =
         new Order(
@@ -108,7 +112,21 @@ public class PizzaStoreStateStoreIT {
                     .body("orders.customer.email", hasItem("alice@example.com")));
   }
 
+  // GET /order against a fresh kvstore (no orders persisted yet) must return
+  // 200 — the controller relies on the State response carrying a null value
+  // being passed through to the JSON serializer. Regressions where an NPE
+  // leaks through (e.g., `state.getValue().orders.size()` unguarded) would
+  // surface here. @Order(1) guarantees this runs before any place-order test
+  // mutates the state store; without it, JUnit 5's default deterministic-but-
+  // unspecified ordering would let other tests slip ahead and pollute state.
   @Test
+  @org.junit.jupiter.api.Order(1)
+  public void getOrderReturnsOkOnEmptyState() {
+    get("/order").then().assertThat().statusCode(200);
+  }
+
+  @Test
+  @org.junit.jupiter.api.Order(2)
   public void persistsMultipleOrders() {
     Order order1 =
         new Order(

--- a/pizza-store/src/test/java/io/diagrid/dapr/PizzaStoreTest.java
+++ b/pizza-store/src/test/java/io/diagrid/dapr/PizzaStoreTest.java
@@ -139,4 +139,72 @@ public class PizzaStoreTest {
 
     get("/order").then().assertThat().statusCode(200).body("orders", notNullValue());
   }
+
+  // POST /events with the wrong Content-Type must be rejected by the
+  // CloudEvents content-negotiation filter (consumes =
+  // "application/cloudevents+json"). Spring returns 415 Unsupported Media Type
+  // before the controller method runs.
+  @Test
+  public void testReceiveEventRejectsWrongContentType() {
+    String wellFormedCloudEvent =
+        """
+        {
+            "specversion": "1.0",
+            "type": "com.dapr.pizza.event",
+            "data": {
+                "type": "order-in-preparation",
+                "service": "kitchen",
+                "message": "x",
+                "order": {
+                    "customer": {"name": "c", "email": "c@c"},
+                    "items": [{"type": "pepperoni", "amount": 1}],
+                    "id": "test-415",
+                    "orderDate": "2023-10-31T18:13:55.571+00:00",
+                    "status": "inpreparation"
+                }
+            }
+        }
+        """;
+    with()
+        .body(wellFormedCloudEvent)
+        .contentType(ContentType.JSON) // application/json — not cloudevents+json
+        .when()
+        .request("POST", "/events")
+        .then()
+        .assertThat()
+        .statusCode(415);
+  }
+
+  // Malformed JSON body to /events must be rejected with 400 by Jackson's
+  // HttpMessageNotReadable handler before the @RestController method runs.
+  @Test
+  public void testReceiveEventRejectsMalformedBody() {
+    with()
+        .body("{ this is not json }")
+        .contentType("application/cloudevents+json")
+        .when()
+        .request("POST", "/events")
+        .then()
+        .assertThat()
+        .statusCode(400);
+  }
+
+  // Verify the externalised CORS allowed-origins placeholder resolves at
+  // request time. ${cors.allowed-origins:http://localhost:5173} on the
+  // @CrossOrigin annotation should populate Access-Control-Allow-Origin on
+  // the preflight response when the test container's default value is in use.
+  @Test
+  public void testCorsAllowedOriginsResolvesPlaceholder() {
+    with()
+        .header("Origin", "http://localhost:5173")
+        .header("Access-Control-Request-Method", "POST")
+        .when()
+        .request("OPTIONS", "/order")
+        .then()
+        .assertThat()
+        .statusCode(
+            org.hamcrest.Matchers.anyOf(
+                org.hamcrest.Matchers.is(200), org.hamcrest.Matchers.is(204)))
+        .header("Access-Control-Allow-Origin", "http://localhost:5173");
+  }
 }

--- a/pizza-store/src/test/java/io/diagrid/dapr/WebSocketBroadcastIT.java
+++ b/pizza-store/src/test/java/io/diagrid/dapr/WebSocketBroadcastIT.java
@@ -148,4 +148,83 @@ public class WebSocketBroadcastIT {
     session.disconnect();
     stompClient.stop();
   }
+
+  // Posting a CloudEvent with an EventType that PizzaStore.receiveEvents has
+  // no branch for (e.g., ORDER_PLACED arriving back from the bus) MUST still
+  // (a) succeed (no 500) and (b) broadcast the inbound event over the WS so
+  // browsers see every state transition — even ones the store doesn't act
+  // on. Regression guard: if a future refactor adds an early-return for
+  // unknown types, this test fails and surfaces the broken WS contract.
+  @Test
+  public void broadcastsUnknownEventTypeOverWebSocket() throws Exception {
+    WebSocketStompClient stompClient = new WebSocketStompClient(new StandardWebSocketClient());
+    stompClient.setMessageConverter(new JacksonJsonMessageConverter());
+
+    BlockingQueue<Map<String, Object>> received = new LinkedBlockingQueue<>();
+
+    String url = "ws://localhost:" + APP_PORT + "/ws";
+    StompSession session =
+        stompClient
+            .connectAsync(url, new StompSessionHandlerAdapter() {})
+            .get(10, java.util.concurrent.TimeUnit.SECONDS);
+
+    session.subscribe(
+        "/topic/events",
+        new StompFrameHandler() {
+          @Override
+          public Type getPayloadType(StompHeaders headers) {
+            return Map.class;
+          }
+
+          @SuppressWarnings("unchecked")
+          @Override
+          public void handleFrame(StompHeaders headers, Object payload) {
+            received.add((Map<String, Object>) payload);
+          }
+        });
+
+    Thread.sleep(500);
+
+    String unknownTypeEvent =
+        """
+        {
+            "specversion": "1.0",
+            "type": "com.dapr.pizza.event",
+            "data": {
+                "type": "order-placed",
+                "service": "store",
+                "message": "echo from bus",
+                "order": {
+                    "customer": {"name": "carol", "email": "carol@example.com"},
+                    "items": [{"type": "margherita", "amount": 1}],
+                    "id": "echo-1",
+                    "orderDate": "2026-05-05T12:00:00.000+00:00",
+                    "status": "created"
+                }
+            }
+        }
+        """;
+
+    with()
+        .body(unknownTypeEvent)
+        .contentType("application/cloudevents+json")
+        .when()
+        .request("POST", "/events")
+        .then()
+        .assertThat()
+        .statusCode(200);
+
+    await()
+        .atMost(Duration.ofSeconds(15))
+        .pollInterval(Duration.ofMillis(250))
+        .until(() -> !received.isEmpty());
+
+    Map<String, Object> event = received.peek();
+    assertNotNull(event, "WS broadcast must fire even for EventTypes the store has no branch for");
+    assertEquals("order-placed", event.get("type"), "Inbound event type must propagate");
+    assertEquals("store", event.get("service"), "Inbound event service must propagate");
+
+    session.disconnect();
+    stompClient.stop();
+  }
 }

--- a/pom.xml
+++ b/pom.xml
@@ -32,11 +32,11 @@
         <wiremock-testcontainers.version>1.0-alpha-15</wiremock-testcontainers.version>
         <wiremock.version>3.13.2</wiremock.version>
         <testcontainers-dapr.version>${dapr.version}</testcontainers-dapr.version>
-        <grpc.version>1.80.0</grpc.version>
+        <grpc.version>1.81.0</grpc.version>
         <protobuf-java.version>4.34.1</protobuf-java.version>
-        <tomcat.version>11.0.21</tomcat.version>
-        <jackson.version>3.1.2</jackson.version>
-        <jackson-bom.version>3.1.2</jackson-bom.version>
+        <tomcat.version>11.0.22</tomcat.version>
+        <jackson.version>3.1.3</jackson.version>
+        <jackson-bom.version>3.1.3</jackson-bom.version>
     </properties>
 
     <dependencyManagement>
@@ -270,7 +270,7 @@
                 <plugin>
                     <groupId>org.owasp</groupId>
                     <artifactId>dependency-check-maven</artifactId>
-                    <version>12.2.1</version>
+                    <version>12.2.2</version>
                     <configuration>
                         <failBuildOnCVSS>7</failBuildOnCVSS>
                         <skipProvidedScope>true</skipProvidedScope>


### PR DESCRIPTION
## Summary

Follow-up to #74. Implements the test-coverage gaps identified by `/project-review` and the deferred image-hardening items (multi-arch publish + DAST baseline).

### `/test-coverage-analysis` Phase 4 (commit 4d82dd2)
- **CORS externalization**: `@CrossOrigin(origins = "${cors.allowed-origins:http://localhost:5173}")` SpEL placeholder; `CORS_ALLOWED_ORIGINS` env wired into both `k8s/` and `k8s-dapr-shared/` manifests
- **Negative-path tests**:
  - `PizzaStoreTest`: 415 (wrong content-type), 400 (malformed body), CORS preflight echo
  - `PizzaKitchenTest`, `PizzaDeliveryTest`: 400 malformed body
- **`PizzaStoreStateStoreIT`**: `@TestMethodOrder` + `@Order(1)` empty-state test that runs first against fresh kvstore
- **`WebSocketBroadcastIT`**: unknown-EventType test asserting WS still broadcasts (regression guard)
- **`OrderJsonTest` (new, pure unit)**: exhaustive `@JsonCreator` defaulting coverage (id/orderDate/status defaults, copy-ctor, round-trip, fresh-UUID-per-default invariant) — runs in ms, no Dapr/Spring container
- **`e2e/e2e-test.sh`**: WebSocket broadcast assertion via `websocat` (regression guard for the PUBLIC_IP-hardcoded WS bug retired 2026-04-26)
- **`k8s-validate` (new Makefile target)**: `kubeconform` validates both `k8s/` and `k8s-dapr-shared/` against vendored OpenAPI on every push — closes the silent-drift gap on the unused alternate "shared sidecar" topology
- `.mise.toml`: `cargo:websocat 1.14.0` + `kubeconform 0.7.0`

### `/harden-image-pipeline` (commit fce886b)
- **Multi-arch publish**: `docker` job is now a per-service-per-arch matrix (6 runners): `{pizza-store, pizza-kitchen, pizza-delivery} × {amd64, arm64}`. arm64 uses `ubuntu-24.04-arm` because Paketo CNB only builds the host arch. Each runner pushes `:<version>-<arch>`.
- **`docker-manifest` (new job)**: assembles the multi-arch manifest list with `docker buildx imagetools create`, pushes both `:<version>` and `:latest`, cosign-signs the manifest digest (one signature covers both archs)
- **OWASP ZAP baseline DAST**: runs after the e2e assertion suite against the LB-exposed pizza-store; SARIF + reports uploaded as artifacts; `continue-on-error: true` while baseline budget is established
- All new actions SHA-pinned (`docker/setup-buildx-action@v4.0.0`, `zaproxy/action-baseline@v0.14.0`)
- README + CLAUDE.md updated for the new docker matrix, docker-manifest, ZAP step, k8s-validate gate

## Test plan

- [ ] `make static-check` passes (now includes `k8s-validate`)
- [ ] `make test` — 14 pizza-store tests (was 4) + 7 OrderJsonTest + 2 kitchen + 2 delivery
- [ ] `make integration-test` — empty-state + unknown-EventType IT additions
- [ ] `make e2e` — WebSocket assertion fires (requires `mise install` for `websocat`)
- [ ] CI `docker` matrix: 6 jobs spawn (3 services × 2 archs)
- [ ] CI `docker-manifest` assembles + signs multi-arch manifest
- [ ] CI `e2e` runs ZAP baseline + uploads `zap-baseline-report` artifact
- [ ] `cosign verify` against the manifest digest succeeds for both archs

## Notes

- Local validation: `make format-check`, `make lint`, `make trivy-fs`, `make trivy-config`, `make secrets`, `make mermaid-lint`, `make k8s-validate` — all pass; `mvn test` shows 25 tests across the 3 modules (was 18).
- ZAP baseline is `continue-on-error` for now — promote to strict once a clean baseline is established and a regression budget is set.
