### PR TITLE
fix(renovate): drop nonexistent java-version manager from enabledManagers

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -9,7 +9,6 @@
     "maven",
     "github-actions",
     "kubernetes",
-    "java-version",
     "custom.regex"
   ],
   "kubernetes": {


### PR DESCRIPTION
## Summary

**One-line fix**: remove `"java-version"` from `enabledManagers` in `renovate.json`. There is no `java-version` manager in Renovate — `npx renovate --platform=local` rejects the config with `The following managers configured in enabledManagers are not supported: "java-version"`, which means Renovate silently stops processing the repo on every scheduled run.

## Background

`"java-version"` was added during the `/project-review` apply on PR #74 based on a misreading of the `/renovate` skill (which itself had been incorrectly updated). The error wasn't caught because:
- `make renovate-validate` wasn't run after the project-review changes landed.
- The Renovate dashboard issue (#4) didn't surface a config-validation error visibly to a casual scan.
- `npx renovate --platform=local` only flags it when invoked directly.

## What still tracks Java upgrades

`.mise.toml` line:

```toml
# renovate: datasource=java-version depName=java
java = "temurin-21.0.10+7.0.LTS"
```

The `mise` manager (which IS real) processes this entry; the `# renovate:` annotation drives Adoptium LTS lookups via the `java-version` **datasource** (different concept from a manager). `.java-version` (containing `21`) is an `actions/setup-java` `java-version-file:` hint and stays as-is.

## Skill update

The `/renovate` skill (`~/.claude/commands/renovate.md`) has been corrected in the same session:
- Removed the bogus `java-version` row from the "Manager selection by file type" table.
- Removed `"java-version"` from the example `enabledManagers` JSON snippet.
- Added an explicit "**There is NO `java-version` manager in Renovate**" warning citing this incident, with the URL to verify against the live manager list.
- Documented the correct path: pin Java in `.mise.toml` (mise tracks it via `datasource=java-version`); `.java-version` stays as a setup-java hint.

The cron `sync.sh` job auto-commits and pushes claude-config changes within 15 min.

## Test plan

- [x] `make renovate-validate` exits clean (only the "GitHub token required" advisory warning remains, unrelated to config validity)
- [ ] CI `ci-pass` aggregator green
- [ ] After merge, verify Renovate's next scheduled run produces dep updates (not config-error issue)
