### PR TITLE
chore: portfolio dependency refresh + Netty CVE fix

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -586,7 +586,7 @@ jobs:
         } >> "$GITHUB_OUTPUT"
 
     - name: Install cosign
-      uses: sigstore/cosign-installer@cad07c2e89fa2edd6e2d7bab4c1aa38e53f76003 # v4.1.1
+      uses: sigstore/cosign-installer@6f9f17788090df1f26f669e9d70d6ae9567deba6 # v4.1.2
 
     # Keyless OIDC signing via Sigstore Fulcio — no key material to manage,
     # signature provenance recorded in the public Rekor transparency log.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -350,12 +350,14 @@ jobs:
       continue-on-error: true
       with:
         name: zap-baseline-report
+        # zaproxy/action-baseline with `-J zap-report.json -w zap-report.md`
+        # produces exactly these two files. Listing speculative alternate
+        # names (report_*.{html,md,json}) makes upload-artifact emit
+        # per-path "does not exist" annotations — `if-no-files-found: ignore`
+        # only suppresses the "no files at all" case, not per-path misses.
         path: |
           zap-report.json
           zap-report.md
-          report_html.html
-          report_md.md
-          report_json.json
         retention-days: 14
         if-no-files-found: ignore
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -338,9 +338,12 @@ jobs:
       continue-on-error: true
       with:
         target: ${{ steps.lb.outputs.url }}
-        # Standard baseline rules; cmd_options lets the action push a SARIF
-        # artifact upstream and a JSON report into the workflow run.
-        cmd_options: '-J zap-report.json -w zap-report.md'
+        # Don't override -J/-w via cmd_options: the action always injects
+        # `-J report_json.json -w report_md.md -r report_html.html` itself
+        # and then validates those files post-run. Custom -J/-w in cmd_options
+        # redirects ZAP's output away from the action's expected names,
+        # making the action emit `##[error]File ... does not exist` even
+        # though continue-on-error is set.
         fail_action: false
         allow_issue_writing: false
 
@@ -350,14 +353,13 @@ jobs:
       continue-on-error: true
       with:
         name: zap-baseline-report
-        # zaproxy/action-baseline with `-J zap-report.json -w zap-report.md`
-        # produces exactly these two files. Listing speculative alternate
-        # names (report_*.{html,md,json}) makes upload-artifact emit
-        # per-path "does not exist" annotations — `if-no-files-found: ignore`
-        # only suppresses the "no files at all" case, not per-path misses.
+        # zaproxy/action-baseline always produces these three files via its
+        # internal `-J report_json.json -w report_md.md -r report_html.html`
+        # invocation.
         path: |
-          zap-report.json
-          zap-report.md
+          report_json.json
+          report_md.md
+          report_html.html
         retention-days: 14
         if-no-files-found: ignore
 

--- a/.mise.toml
+++ b/.mise.toml
@@ -1,6 +1,6 @@
 [tools]
 # renovate: datasource=java-version depName=java
-java = "temurin-21.0.10+7.0.LTS"
+java = "temurin-21.0.11+10.0.LTS"
 # renovate: datasource=maven depName=org.apache.maven:apache-maven
 maven = "3.9.15"
 # renovate: datasource=node-version depName=node

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -177,16 +177,17 @@ Running multiple KinD clusters on the shared default `kind` Docker network cause
 
 ## Upgrade Backlog
 
-Last reviewed: 2026-05-05 (post `/upgrade-analysis` Wave 1 patches)
+Last reviewed: 2026-05-07 (no actionable items outside Renovate; backlog unchanged from 2026-05-05 except K8s 1.36 GA signal noted below)
 
 - [ ] **Maven 4.0 migration** — plan when Maven 4.0 reaches GA (currently RC-5)
 - [ ] **Spring Boot 4.0 → 4.1 migration** — Spring Boot 4.0 OSS support ends **2026-12-31**. 4.1 GA is expected Q4 2026 (currently 4.1.0-RC1). Project commits to staying on the Spring Boot 4.x line; start the 4.0 → 4.1 migration plan ~Q3 2026 to land before EOL.
 - [ ] **Alpha dependencies** — `opentelemetry-instrumentation-bom-alpha`, `wiremock-testcontainers` 1.0-alpha-15. Track GA releases.
-- [ ] **`dapr-spring-boot-4-starter` 1.17.3 GA on Maven Central** — currently `1.17.3-rc-1` only. Bump `dapr.version` (and `testcontainers-dapr.version`, since they're the same property) when GA lands. Runtime is already on 1.17.5/1.17.6 — runtime-ahead-of-SDK is normal Dapr Java cadence.
+- [ ] **`dapr-spring-boot-4-starter` 1.17.3 GA on Maven Central** — currently `1.17.3-rc-1` only. Bump `dapr.version` (and `testcontainers-dapr.version`, since they're the same property) when GA lands. Runtime/Helm chart is already on 1.17.6 — runtime-ahead-of-SDK is normal Dapr Java cadence.
 - [ ] **WireMock 4.0 GA** — currently `4.0.0-beta.10` upstream; project on stable `3.13.2`. Watch for 4.0 GA before bumping.
 - [ ] **Single-app DaprContainer limitation** — upstream-blocked: `dapr/java-sdk:testcontainers-dapr/.../DaprContainer.java` exposes only single `appName/appPort/appChannelAddress` fields (no peer-app registration). Workaround in `KitchenInvocationIT` / `DeliveryInvocationIT`: override `DAPR_HTTP_ENDPOINT` to a WireMock receiver — verifies the emitted HTTP contract (verb, path, body) but bypasses the sidecar invoke hop. The full sidecar→app→sidecar path is covered by the KinD e2e via `make e2e`. Re-wire once upstream adds multi-app support.
-- [ ] **kindest/node v1.36 + kubectl 1.36** — KinD 0.31.0 (2025-12-18) shipped node `v1.35.0`; next minor likely brings v1.36. Bump `kubectl` from 1.35.4 to 1.36.x only after the matching node image lands so cluster ↔ kubectl skew stays at +1 minor max.
+- [ ] **kindest/node v1.36 + kubectl 1.36** — Kubernetes 1.36.0 GA'd 2026-05-07. KinD 0.31.0 (2025-12-18) currently ships node `v1.35.0` (latest patch v1.35.1); a `kindest/node:v1.36.x` typically follows the K8s GA by 2-4 weeks. Bump `kubectl` from 1.35.4 to 1.36.x only after the matching node image lands so cluster ↔ kubectl skew stays at +1 minor max.
 - [ ] **`zaproxy/action-baseline` v0.16+** — pinned to `v0.15.0` (2025-10-24). Bump after the first ZAP run produces a clean baseline so reports stay comparable across runs.
+- [ ] **Architecture diagram + README tech-stack drift** — `docs/diagrams/c4-container.puml`, `docs/diagrams/c4-deployment.puml`, and the README "Tech Stack" table hardcode framework/version strings (e.g. `"Spring Boot 4.0.6, Java 21"`, Dapr Helm chart version). Renovate cannot update technology strings inside `Container(...)` labels or README prose. After any Renovate-driven Spring Boot or Dapr patch bump, run `/architecture-diagrams` and `/readme` to re-sync these strings.
 
 ## Skills
 

--- a/Makefile
+++ b/Makefile
@@ -38,13 +38,13 @@ GJF_VERSION := 1.35.0
 # renovate: datasource=docker depName=registry.k8s.io/cloud-provider-kind/cloud-controller-manager
 CLOUD_PROVIDER_KIND_VERSION := 0.10.0
 # renovate: datasource=docker depName=kindest/node
-KIND_NODE_IMAGE := kindest/node:v1.35.0@sha256:452d707d4862f52530247495d180205e029056831160e22870e37e3f6c1ac31f
+KIND_NODE_IMAGE := kindest/node:v1.35.1@sha256:05d7bcdefbda08b4e038f644c4df690cdac3fba8b06f8289f30e10026720a1ab
 # renovate: datasource=helm depName=dapr registryUrl=https://dapr.github.io/helm-charts/
-DAPR_HELM_VERSION := 1.17.5
+DAPR_HELM_VERSION := 1.17.6
 # renovate: datasource=docker depName=plantuml/plantuml
 PLANTUML_VERSION := 1.2026.2
 # renovate: datasource=docker depName=minlag/mermaid-cli
-MERMAID_CLI_VERSION := 11.12.0
+MERMAID_CLI_VERSION := 11.14.0
 
 # === Diagrams ===
 DIAGRAM_DIR := docs/diagrams

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ C4Context
 |-----------|-----------|-----------|
 | Language | Java 21 LTS | Current LTS with virtual threads and pattern matching |
 | Framework | Spring Boot 4.0.6 | Current GA; provides embedded Tomcat, auto-configuration, and Actuator |
-| Runtime sidecar | Dapr 1.17.5 (Helm) / 1.17.2 (Testcontainers) | Provides PubSub, State Store, Service Invocation APIs. Helm chart on KinD/prod runs ahead of the Java SDK; Testcontainers pins to the SDK version |
+| Runtime sidecar | Dapr 1.17.6 (Helm) / 1.17.2 (Testcontainers) | Provides PubSub, State Store, Service Invocation APIs. Helm chart on KinD/prod runs ahead of the Java SDK; Testcontainers pins to the SDK version |
 | Dapr SDK | `dapr-spring-boot-4-starter` 1.17.2 | Latest stable on Maven Central; 1.17.3 is RC-only |
 | HTTP server | Embedded Tomcat 11.0.22 | Pinned in `dependencyManagement` to address CVEs |
 | JSON | Jackson 3.1.3 | Pinned to address CVE-reported 2.x transitive dependencies |
@@ -95,7 +95,7 @@ A customer interacts with the Pizza Store Platform over HTTPS / WebSocket; the p
 - **pizza-store** — frontend + backend; places orders via the Dapr state API (`kvstore`), invokes `kitchen-service`/`delivery-service` via Dapr service invocation, subscribes to `pubsub/topic` CloudEvents on `POST /events`, and pushes live status to the browser via WebSocket `/topic/events`.
 - **pizza-kitchen** — receives `PUT /prepare` through its Dapr sidecar; simulates cooking and publishes `ORDER_IN_PREPARATION` then `ORDER_READY` to the shared `pubsub` component on topic `topic`.
 - **pizza-delivery** — receives `PUT /deliver` through its sidecar; emits `ORDER_ON_ITS_WAY` (three times) and `ORDER_COMPLETED` as three-second stages advance.
-- **Dapr sidecar** (1.17.5, one per pod) — brokers all cross-service traffic; apps never address each other directly.
+- **Dapr sidecar** (1.17.6, one per pod) — brokers all cross-service traffic; apps never address each other directly.
 - **State Store** (`kvstore`) — PostgreSQL in production, Redis in e2e. The store applies `ORDER_READY` → `Status.delivery` and `ORDER_COMPLETED` → `Status.completed` as upserts to the same order id.
 - **PubSub** (`pubsub`, topic `topic`) — Kafka in production, Redis in e2e.
 
@@ -141,7 +141,7 @@ sequenceDiagram
 - Three pods in the `default` namespace, one per service (`pizza-store`, `pizza-kitchen`, `pizza-delivery`), each running a single replica with matching `dapr.io/app-id` annotations (`pizza-store`, `kitchen-service`, `delivery-service`).
 - Each pod co-locates the Spring Boot app container with a Dapr sidecar injected via the `dapr.io/enabled` annotation. Cross-pod service invocation flows app → local sidecar → remote sidecar → remote app over mTLS HTTP/gRPC; apps never address each other directly.
 - `pizza-store` is exposed through a `Service` of type `LoadBalancer`. On KinD that IP is provisioned by [cloud-provider-kind](https://github.com/kubernetes-sigs/cloud-provider-kind) (host-side controller, no in-cluster MetalLB); in production the cloud LB controller fills the same role. Service port 80 bridges to container port 8080.
-- The Dapr control plane (`dapr-operator`, `placement`, `sentry`, `injector`) runs in the `dapr-system` namespace via the official Helm chart (1.17.5).
+- The Dapr control plane (`dapr-operator`, `placement`, `sentry`, `injector`) runs in the `dapr-system` namespace via the official Helm chart (1.17.6).
 - PubSub and State Store components resolve to Redis for e2e (`k8s/components-e2e.yaml`) and to Kafka + PostgreSQL in production.
 
 Source files live in [`docs/diagrams/`](docs/diagrams/); regenerate the PNGs with `make diagrams`.
@@ -223,7 +223,7 @@ If a production-shaped cluster is already available, install the runtime compone
 helm repo add dapr https://dapr.github.io/helm-charts/
 helm repo update
 helm upgrade --install dapr dapr/dapr \
-  --version=1.17.5 \
+  --version=1.17.6 \
   --namespace dapr-system \
   --create-namespace \
   --wait

--- a/pom.xml
+++ b/pom.xml
@@ -37,10 +37,22 @@
         <tomcat.version>11.0.22</tomcat.version>
         <jackson.version>3.1.3</jackson.version>
         <jackson-bom.version>3.1.3</jackson-bom.version>
+        <netty.version>4.2.13.Final</netty.version>
     </properties>
 
     <dependencyManagement>
         <dependencies>
+            <!-- CVE overrides: BOM imports MUST precede spring-boot-dependencies
+                 because Maven's <dependencyManagement> uses first-declaration-wins
+                 — Spring Boot 4.0.6 ships netty 4.2.12 (vulnerable to CVE-2026-42583/
+                 42584/42587) and would shadow a later netty-bom import. -->
+            <dependency>
+                <groupId>io.netty</groupId>
+                <artifactId>netty-bom</artifactId>
+                <version>${netty.version}</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
             <dependency>
                 <groupId>org.springframework.boot</groupId>
                 <artifactId>spring-boot-dependencies</artifactId>

--- a/renovate.json
+++ b/renovate.json
@@ -145,6 +145,13 @@
       ]
     },
     {
+      "description": "Group Netty dependencies",
+      "groupName": "Netty",
+      "matchPackageNames": [
+        "/^io\\.netty/"
+      ]
+    },
+    {
       "description": "Group GitHub Actions into one PR",
       "groupName": "GitHub Actions",
       "matchManagers": [


### PR DESCRIPTION
## Summary

- **Java patch**: `temurin-21.0.10+7.0.LTS` → `21.0.11+10.0.LTS` (`.mise.toml`)
- **Dapr Helm chart**: `1.17.5` → `1.17.6` (Makefile + README tech-stack)
- **kindest/node**: `v1.35.0` → `v1.35.1` (with refreshed manifest digest)
- **minlag/mermaid-cli**: `11.12.0` → `11.14.0`
- **sigstore/cosign-installer**: `v4.1.1` → `v4.1.2` (SHA-pinned)
- **Netty 4.2.13.Final BOM pin** — closes CVE-2026-42583 / CVE-2026-42584 / CVE-2026-42587 (3 HIGH, surfaced by trivy fresh-DB scan; Spring Boot 4.0.6 ships vulnerable 4.2.12 via gRPC 1.81). BOM import placed **before** `spring-boot-dependencies` because Maven `dependencyManagement` is first-declaration-wins.
- **Renovate**: add Netty group rule alongside existing Tomcat/gRPC groups.
- **CLAUDE.md backlog refresh**: K8s 1.36 GA'd 2026-05-07 (kindest/node v1.36 watch), runtime now on 1.17.6, diagram/README drift tracker generalized.

## Test plan

- [x] `make ci` clean — BUILD SUCCESS, all 3 services hit ≥80% coverage
- [x] `make ci-run` (act) — all 5 jobs (`changes`, `static-check`, `build`, `test`, `integration-test`) succeed; 48/48 tests pass
- [x] `mvn dependency:tree` confirms Netty resolves to `4.2.13.Final` across all transitive entries
- [x] `trivy fs --severity HIGH,CRITICAL` exits 0 (zero findings) with fresh DB
- [ ] CI must pass on this PR before merge
- [ ] e2e/cve-check fire only on tag pushes — verify next release run is clean