### PR TITLE
docs(claude): move diagram-drift item from Upgrade Backlog to Key Config

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -175,6 +175,10 @@ Running multiple KinD clusters on the shared default `kind` Docker network cause
 - `make k8s-validate` (kubeconform) validates `k8s/` and `k8s-dapr-shared/` against vendored OpenAPI on every push, so drift in the unused alternate "shared sidecar" topology surfaces immediately.
 - `e2e` job runs an OWASP ZAP baseline DAST scan against the LB-exposed pizza-store after the assertion suite passes (`continue-on-error: true` while baseline budget is established).
 
+### Documentation drift across Renovate-driven version bumps
+
+`docs/diagrams/c4-container.puml`, `docs/diagrams/c4-deployment.puml`, and the README "Tech Stack" table hardcode framework/version strings (Spring Boot, Java, Dapr Helm chart). Renovate cannot update technology strings inside `Container(...)` PUML labels or README prose — both files drift silently after a Spring Boot or Dapr patch bump lands. After any such Renovate-driven bump, run `/architecture-diagrams` and `/readme` to re-sync these strings; do NOT rely on the diagrams-check or mermaid-lint gates to catch this — they validate parse, not content.
+
 ## Upgrade Backlog
 
 Last reviewed: 2026-05-07 (no actionable items outside Renovate; backlog unchanged from 2026-05-05 except K8s 1.36 GA signal noted below)
@@ -187,7 +191,6 @@ Last reviewed: 2026-05-07 (no actionable items outside Renovate; backlog unchang
 - [ ] **Single-app DaprContainer limitation** — upstream-blocked: `dapr/java-sdk:testcontainers-dapr/.../DaprContainer.java` exposes only single `appName/appPort/appChannelAddress` fields (no peer-app registration). Workaround in `KitchenInvocationIT` / `DeliveryInvocationIT`: override `DAPR_HTTP_ENDPOINT` to a WireMock receiver — verifies the emitted HTTP contract (verb, path, body) but bypasses the sidecar invoke hop. The full sidecar→app→sidecar path is covered by the KinD e2e via `make e2e`. Re-wire once upstream adds multi-app support.
 - [ ] **kindest/node v1.36 + kubectl 1.36** — Kubernetes 1.36.0 GA'd 2026-05-07. KinD 0.31.0 (2025-12-18) currently ships node `v1.35.0` (latest patch v1.35.1); a `kindest/node:v1.36.x` typically follows the K8s GA by 2-4 weeks. Bump `kubectl` from 1.35.4 to 1.36.x only after the matching node image lands so cluster ↔ kubectl skew stays at +1 minor max.
 - [ ] **`zaproxy/action-baseline` v0.16+** — pinned to `v0.15.0` (2025-10-24). Bump after the first ZAP run produces a clean baseline so reports stay comparable across runs.
-- [ ] **Architecture diagram + README tech-stack drift** — `docs/diagrams/c4-container.puml`, `docs/diagrams/c4-deployment.puml`, and the README "Tech Stack" table hardcode framework/version strings (e.g. `"Spring Boot 4.0.6, Java 21"`, Dapr Helm chart version). Renovate cannot update technology strings inside `Container(...)` labels or README prose. After any Renovate-driven Spring Boot or Dapr patch bump, run `/architecture-diagrams` and `/readme` to re-sync these strings.
 
 ## Skills
 


### PR DESCRIPTION
## Summary

Apply `/claude` skill's backlog-hygiene rule. The "Architecture diagram + README tech-stack drift" bullet was added to `## Upgrade Backlog` during the 2026-05-07 upgrade analysis, but it's an **operational reminder** (re-sync after a Renovate-driven Spring Boot or Dapr bump), not an upstream-blocked deferral. Per the skill's class-(a)/(b)/(c)/(d)/(e) classification, operational reminders belong in `## Key Config` — reachable from the per-bump workflow, not buried in a list of "things to do later when upstream X happens."

- New `### Documentation drift across Renovate-driven version bumps` subsection under Key Config explains the drift surface (PUML `Container(...)` labels + README "Tech Stack" prose) and prescribes the remediation (`/architecture-diagrams` + `/readme`)
- Removed the redundant bullet from Upgrade Backlog

Backlog now has 8 items, all genuinely upstream-blocked (Spring Boot 4.1 GA, Maven 4.0 GA, Dapr SDK 1.17.3 GA, WireMock 4.0 GA, alpha deps, single-app DaprContainer upstream feature, kindest/node v1.36, ZAP baseline v0.16).

## Test plan

- [x] `/claude` skill checklist passes (Skills section canonical, mermaid-cli mentioned, three-layer test pyramid present, backlog all class-(a))
- [ ] CI passes on this PR (docs-only — `changes` job will skip the heavy work)