### PR TITLE
chore(renovate): adopt native mise manager; drop .mise.toml from custom.regex

### DIFF
--- a/.mise.toml
+++ b/.mise.toml
@@ -1,26 +1,22 @@
 [tools]
-# renovate: datasource=java-version depName=java
+# All entries below are tracked natively by Renovate's `mise` manager
+# (https://docs.renovatebot.com/modules/manager/mise/). `# renovate:`
+# annotations are deliberately omitted — the mise manager doesn't consult
+# them, and re-adding them would mislead reviewers into thinking a
+# custom.regex manager is involved (see /renovate skill §".mise.toml
+# Renovate custom manager — DO NOT ADD ONE").
 java = "temurin-21.0.11+10.0.LTS"
-# renovate: datasource=maven depName=org.apache.maven:apache-maven
 maven = "3.9.15"
-# renovate: datasource=node-version depName=node
 node = "22.22.2"
-# renovate: datasource=github-releases depName=nektos/act
 act = "0.2.88"
-# renovate: datasource=github-releases depName=aquasecurity/trivy
 trivy = "0.70.0"
-# renovate: datasource=github-releases depName=gitleaks/gitleaks
 gitleaks = "8.30.1"
-# renovate: datasource=github-releases depName=kubernetes-sigs/kind
 kind = "0.31.0"
-# renovate: datasource=github-releases depName=kubernetes/kubernetes
 kubectl = "1.35.4"
-# renovate: datasource=github-releases depName=helm/helm
 helm = "4.1.4"
 # kubeconform validates k8s manifest YAML against vendored OpenAPI schemas
 # (no cluster needed). Used by `make k8s-validate` to gate every push on
 # both k8s/ and k8s-dapr-shared/ parsing cleanly.
-# renovate: datasource=github-releases depName=yannh/kubeconform
 kubeconform = "0.7.0"
 # websocat is a single-binary WebSocket client used by e2e/e2e-test.sh to
 # assert STOMP broadcast over the LB-exposed /ws endpoint (regression guard
@@ -28,5 +24,4 @@ kubeconform = "0.7.0"
 # via mise's aqua backend — precompiled GitHub release binary (instant on
 # both fresh laptops and CI cold runners; the cargo: backend would compile
 # from source for ~1-2 min on cold cache).
-# renovate: datasource=github-releases depName=vi/websocat
 "aqua:vi/websocat" = "1.14.1"

--- a/renovate.json
+++ b/renovate.json
@@ -9,6 +9,7 @@
     "maven",
     "github-actions",
     "kubernetes",
+    "mise",
     "custom.regex"
   ],
   "kubernetes": {
@@ -20,13 +21,12 @@
   "customManagers": [
     {
       "customType": "regex",
-      "description": "Update Makefile/.mise.toml tool versions via inline renovate comments",
+      "description": "Update Makefile tool versions via inline renovate comments. .mise.toml is handled by the native `mise` manager — do not add it here (would duplicate every dep).",
       "managerFilePatterns": [
-        "/(^|/)Makefile$/",
-        "/(^|/)\\.mise\\.toml$/"
+        "/(^|/)Makefile$/"
       ],
       "matchStrings": [
-        "# renovate: datasource=(?<datasource>[a-z-]+?)(?: depName=(?<depName>[^\\s]+?))?(?: packageName=(?<packageName>[^\\s]+?))?(?: versioning=(?<versioning>[a-z-]+?))?\\s+\\S+?\\s*[:=]?\\s*[\"']?(?<currentValue>[^\"'\\s]+)[\"']?"
+        "# renovate: datasource=(?<datasource>[a-z-]+?)(?: depName=(?<depName>[^\\s]+?))?(?: packageName=(?<packageName>[^\\s]+?))?(?: versioning=(?<versioning>[a-z-]+?))?\\s+\\S+?\\s*[?:]?=\\s*[\"']?(?<currentValue>[^\"'\\s]+)[\"']?"
       ]
     }
   ],


### PR DESCRIPTION
## Summary

Apply the optional MEDIUM finding from the recent `/project-review` (PR #80 chain) — switch `.mise.toml` from `custom.regex` to Renovate's native `mise` manager, per `/renovate` skill §`.mise.toml Renovate custom manager — DO NOT ADD ONE`.

## Why

Renovate's native `mise` manager extracts every entry in `.mise.toml` directly:
- `core:` tools (java, maven, node) → `golang-version` / `java-version` / `node-version` datasources
- `aqua:` backends → `github-tags` datasource
- `go:` / `asdf:` / `npm:` backends → respective datasources

Pairing this with a `custom.regex` over the same file produces duplicate dep tracking and risks fight-to-merge collisions on each upstream bump.

## Changes

- `renovate.json`:
  - `enabledManagers`: add `mise`
  - `customManagers[0].managerFilePatterns`: drop the `/\.mise\.toml$/` glob; Makefile remains the only target
  - `customManagers[0].matchStrings`: bump `:=`-only operator literal to `[?:]?=` (covers `VAR := X`, `VAR ?= X`, `VAR = X` per skill full-coverage rule — defensive, no `?=` in this Makefile today)
- `.mise.toml`: remove dead `# renovate:` annotations (mise manager doesn't consult them; keeping the `renovate:` keyword misleads future readers into thinking custom regex is involved). Useful contextual comments (kubeconform purpose, websocat aqua-vs-cargo backend rationale) preserved.

## Validation

`make renovate-validate`:

| Manager | Before | After |
|---|---|---|
| github-actions | 2 files / 41 deps | 2 / 41 |
| kubernetes | 5 files / 14 deps | 5 / 14 |
| maven | 4 files / 34 deps | 4 / 34 |
| **regex** (Makefile + .mise.toml) | **2 / 17** | **1 / 6** |
| **mise** (.mise.toml) | — | **1 / 11** |
| **Total** | **13 / 106** | **13 / 106** ✓ |

Zero `validationError`. `make static-check` clean.

## Test plan

- [x] `make renovate-validate` — manager stats match expectation, no validation errors
- [x] `make static-check` — passes (mise install unchanged: same 11 tools resolved)
- [ ] CI passes on this PR (docs + config only — `changes` should classify as code via `renovate.json`/`.mise.toml`)