### PR TITLE
fix(cve): suppress CVE-2026-39883 false positive against opentelemetry-semconv (Java vs Go)

### DIFF
--- a/config/owasp/dependency-check-suppressions.xml
+++ b/config/owasp/dependency-check-suppressions.xml
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<suppressions xmlns="https://jeremylong.github.io/DependencyCheck/dependency-suppression.1.3.xsd">
+
+    <!--
+        CVE-2026-39883 — false positive against io.opentelemetry.semconv:opentelemetry-semconv.
+
+        NVD's own description ties this CVE to "OpenTelemetry-Go ... the Go implementation
+        of OpenTelemetry" (PATH-hijack on BSD/Solaris via bare `kenv` command, vulnerable
+        from 1.15.0 to 1.42.0, fixed in 1.43.0). The vulnerable artifact is the Go SDK,
+        not the Java semantic-conventions library this project pulls in. OWASP matched
+        on the CPE `cpe:2.3:a:opentelemetry:opentelemetry:1.41.1` purely because the
+        Java semconv artifact's version happens to fall inside the Go SDK's vulnerable
+        range — different language, different codebase, different release cadence,
+        zero relationship between the two version numbers.
+
+        Sources:
+          - NVD: https://nvd.nist.gov/vuln/detail/CVE-2026-39883
+          - First surfaced: workflow_dispatch run 26412295497 on 2026-05-25.
+    -->
+    <suppress>
+        <notes><![CDATA[
+            CVE-2026-39883 applies to opentelemetry-go (the Go SDK), not to the Java
+            opentelemetry-semconv artifact. CPE-overmatch FP.
+        ]]></notes>
+        <packageUrl regex="true">^pkg:maven/io\.opentelemetry\.semconv/opentelemetry-semconv@.*$</packageUrl>
+        <cve>CVE-2026-39883</cve>
+    </suppress>
+
+</suppressions>

--- a/pom.xml
+++ b/pom.xml
@@ -289,6 +289,12 @@
                         <skipProvidedScope>true</skipProvidedScope>
                         <skipRuntimeScope>false</skipRuntimeScope>
                         <assemblyAnalyzerEnabled>false</assemblyAnalyzerEnabled>
+                        <suppressionFiles>
+                            <!-- Resolved relative to each module's basedir; ${maven.multiModuleProjectDirectory}
+                                 points at the reactor root regardless of which submodule the plugin
+                                 is currently scanning, so a single suppression file covers all services. -->
+                            <suppressionFile>${maven.multiModuleProjectDirectory}/config/owasp/dependency-check-suppressions.xml</suppressionFile>
+                        </suppressionFiles>
                     </configuration>
                 </plugin>
                 <!--


### PR DESCRIPTION
## Summary

Surfaced by workflow_dispatch run [26412295497](https://github.com/AndriyKalashnykov/dapr-java/actions/runs/26412295497) on 2026-05-25, after the plugin-prefix fix in #85 unblocked the actual scan.

**Fact-check.** [CVE-2026-39883](https://nvd.nist.gov/vuln/detail/CVE-2026-39883)'s NVD description reads verbatim:

> OpenTelemetry-**Go** is the **Go implementation** of OpenTelemetry. From 1.15.0 to 1.42.0, the fix for CVE-2026-24051 changed the Darwin ioreg command to use an absolute path but left the BSD kenv command using a bare name, allowing the same PATH hijacking attack on BSD and Solaris platforms.

The vulnerable artifact is the **Go SDK** (PATH-hijack via bare `kenv` command). The Java artifact this project pulls — `io.opentelemetry.semconv:opentelemetry-semconv:1.41.1` — is a separate codebase whose version number happens to fall inside the Go SDK's vulnerable range. OWASP matched on the generic `cpe:2.3:a:opentelemetry:opentelemetry:1.41.1` and produced a textbook CPE-overmatch false positive.

## Fix

`config/owasp/dependency-check-suppressions.xml` carries a `<suppress>` entry scoped to:
- **packageUrl** regex: `^pkg:maven/io\.opentelemetry\.semconv/opentelemetry-semconv@.*$`
- **cve**: `CVE-2026-39883`

Wired via `dependency-check-maven` pluginManagement `<suppressionFiles>` using `\${maven.multiModuleProjectDirectory}` so the single file at the reactor root covers all three service modules.

This is a precise suppression, not a blanket skip — any other CVE against this artifact, or this CVE against a different artifact, still fails the build.

## Test plan

- [x] `xmllint --noout config/owasp/dependency-check-suppressions.xml` — well-formed
- [x] `xmllint --noout pom.xml` — well-formed
- [x] `make static-check` — green
- [ ] PR-level CI green (won't directly exercise cve-check; gated)
- [ ] Post-merge workflow_dispatch of CI on main — proves cve-check passes