### PR TITLE
chore(makefile): add check-java-alignment fail-fast precheck

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -22,7 +22,8 @@ make trivy-config                       # Scan k8s/ and k8s-dapr-shared/ for KSV
 make secrets                            # Scan for leaked secrets (gitleaks)
 make deps-prune                         # Analyze Maven dependencies (advisory)
 make deps-prune-check                   # Fail if unused declared Maven dependencies exist
-make static-check                       # Composite: format-check + lint + trivy-fs + trivy-config + secrets + diagrams-check + mermaid-lint + k8s-validate
+make check-java-alignment               # Fail-fast precheck: Java major matches across .mise.toml, .java-version, pom.xml (java.version + maven.compiler.{source,target})
+make static-check                       # Composite: check-java-alignment + format-check + lint + trivy-fs + trivy-config + secrets + diagrams-check + mermaid-lint + k8s-validate
 make k8s-validate                       # Validate k8s/ + k8s-dapr-shared/ manifests via kubeconform (vendored OpenAPI, no cluster)
 make diagrams                           # Render docs/diagrams/*.puml → docs/diagrams/out/*.png (PlantUML in Docker)
 make diagrams-clean                     # Remove rendered PNGs

--- a/Makefile
+++ b/Makefile
@@ -282,8 +282,35 @@ mermaid-lint:
 			> /dev/null || { echo "FAIL: Mermaid lint failed in $$f"; exit 1; }; \
 	done
 
-#static-check: @ Composite quality gate (format-check + lint + trivy-fs + trivy-config + secrets + diagrams-check + mermaid-lint + k8s-validate)
-static-check: format-check lint trivy-fs trivy-config secrets diagrams-check mermaid-lint k8s-validate
+#check-java-alignment: @ Fail-fast precheck — Java major version must match across .mise.toml, .java-version, and pom.xml (java.version + maven.compiler.{source,target})
+# Renovate's `mise` manager bumps `.mise.toml`'s patch version; `.java-version`
+# and `pom.xml` hold the major-only constraint and Renovate does NOT touch
+# them. A manual edit to `.mise.toml` that crosses a major boundary (e.g.,
+# temurin-21.x → temurin-25.x) without updating the others leaves a hidden
+# disagreement: mise installs Java 25, Maven compiles for 21, CI reads .java-version=21 → silent runtime mismatch at first integration test.
+# This 30-millisecond precheck makes the drift mechanical to detect.
+check-java-alignment:
+	@set -e; \
+	mise_major=$$(awk -F'"' '/^java *= *"/ {print $$2; exit}' .mise.toml | sed -E 's/^temurin-([0-9]+)\..*/\1/'); \
+	jver=$$(tr -d '[:space:]' < .java-version); \
+	pom_jv=$$(grep -oE '<java\.version>[0-9]+</java\.version>' pom.xml | head -1 | sed -E 's/.*>([0-9]+)<.*/\1/'); \
+	pom_src=$$(grep -oE '<maven\.compiler\.source>[0-9]+</maven\.compiler\.source>' pom.xml | head -1 | sed -E 's/.*>([0-9]+)<.*/\1/'); \
+	pom_tgt=$$(grep -oE '<maven\.compiler\.target>[0-9]+</maven\.compiler\.target>' pom.xml | head -1 | sed -E 's/.*>([0-9]+)<.*/\1/'); \
+	if [ "$$mise_major" != "$$jver" ] || [ "$$mise_major" != "$$pom_jv" ] || [ "$$mise_major" != "$$pom_src" ] || [ "$$mise_major" != "$$pom_tgt" ]; then \
+		echo "ERROR: Java major version disagrees across files:"; \
+		printf "  %-32s %s\n" ".mise.toml (java pin, major)"          "$$mise_major"; \
+		printf "  %-32s %s\n" ".java-version"                          "$$jver"; \
+		printf "  %-32s %s\n" "pom.xml <java.version>"                 "$$pom_jv"; \
+		printf "  %-32s %s\n" "pom.xml <maven.compiler.source>"        "$$pom_src"; \
+		printf "  %-32s %s\n" "pom.xml <maven.compiler.target>"        "$$pom_tgt"; \
+		echo "  Persistent fix:"; \
+		echo "    bump every file to the same major (currently .mise.toml = $$mise_major)."; \
+		echo "    update .java-version and pom.xml's three properties together."; \
+		exit 1; \
+	fi
+
+#static-check: @ Composite quality gate (check-java-alignment + format-check + lint + trivy-fs + trivy-config + secrets + diagrams-check + mermaid-lint + k8s-validate)
+static-check: check-java-alignment format-check lint trivy-fs trivy-config secrets diagrams-check mermaid-lint k8s-validate
 	@echo "All static checks passed"
 
 #run: @ Run the application
@@ -680,7 +707,7 @@ release: pre-release
 
 .PHONY: help deps deps-check deps-maven deps-gjf \
 	env-check clean build test integration-test lint format format-check \
-	trivy-fs trivy-config secrets deps-prune deps-prune-check static-check run \
+	trivy-fs trivy-config secrets deps-prune deps-prune-check check-java-alignment static-check run \
 	ci ci-run cve-check coverage-generate coverage-check coverage-open \
 	print-deps-updates update-deps renovate-validate \
 	image-build image-scan image-test kind-create kind-deploy kind-undeploy kind-destroy \


### PR DESCRIPTION
## Summary

Wires a sub-second precheck as the first dep of `make static-check` that verifies the Java major version agrees across `.mise.toml`, `.java-version`, and `pom.xml` (`<java.version>` + `<maven.compiler.source>` + `<maven.compiler.target>`).

**Why:** Renovate's `mise` manager only bumps `.mise.toml`'s patch version; `.java-version` and `pom.xml` hold the major-only constraint and Renovate does NOT touch them. A manual `.mise.toml` edit that crosses a major boundary (e.g. `temurin-21.x` → `temurin-25.x`) leaves a silent disagreement: mise installs Java 25, Maven compiles for 21, CI reads `.java-version=21` — runtime mismatch surfaces only at the first integration test.

This 30-ms precheck makes the drift mechanical to detect, with a copy-paste remediation in the failure output.

## Test plan

- [x] Happy path: current state (all five values at major `21`) → `make check-java-alignment` PASS
- [x] Failure path: corrupted `.java-version` → rc=1, columnar diagnostic dump + "Persistent fix:" remediation
- [x] `bash -n Makefile` clean
- [x] `make ci` (clean → deps → static-check → coverage-generate → coverage-check → build) → BUILD SUCCESS
- [ ] Watch GitHub Actions on this PR

## Notes

- Single-source-of-truth for the major remains `.mise.toml` (Renovate-tracked via the native `mise` manager).
- The precheck's runtime cost (~30 ms) is fast enough to gate every `static-check` invocation without iteration-loop friction.
- Recipe follows the skill's "Fail-fast preflight" template (canonical from `/makefile` §"Generalized fail-fast preflight pattern"): columnar diagnostic + inline `Persistent fix:` remediation so the failure message is operator-actionable.