### PR TITLE
docs(diagrams): reduce architecture-diagram render heights toward ~500px

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,7 +105,7 @@ The Pizza Store application simulates placing a Pizza Order that is processed by
 
 ### Context View
 
-<img src="docs/diagrams/out/c4-context.png" alt="C4 Context diagram — Pizza on Dapr" width="240">
+<img src="docs/diagrams/out/c4-context.png" alt="C4 Context diagram — Pizza on Dapr" width="220">
 
 A customer interacts with the Pizza Store Platform over HTTPS / WebSocket; the platform delegates service invocation, pub/sub, and state persistence to its co-deployed Dapr Runtime (Helm-installed control plane plus per-pod sidecars). Source: [`docs/diagrams/c4-context.puml`](docs/diagrams/c4-context.puml).
 
@@ -118,7 +118,7 @@ A customer interacts with the Pizza Store Platform over HTTPS / WebSocket; the p
 
 ### Container View
 
-<img src="docs/diagrams/out/c4-container.png" alt="C4 Container diagram" width="520">
+<img src="docs/diagrams/out/c4-container.png" alt="C4 Container diagram" width="440">
 
 - **pizza-store** — frontend + backend; places orders via the Dapr state API (`kvstore`), invokes `kitchen-service`/`delivery-service` via Dapr service invocation, subscribes to `pubsub/topic` CloudEvents on `POST /events`, and pushes live status to the browser via WebSocket `/topic/events`.
 - **pizza-kitchen** — receives `PUT /prepare` through its Dapr sidecar; simulates cooking and publishes `ORDER_IN_PREPARATION` then `ORDER_READY` to the shared `pubsub` component on topic `topic`.
@@ -164,7 +164,7 @@ sequenceDiagram
 
 ### Deployment View
 
-<img src="docs/diagrams/out/c4-deployment.png" alt="C4 Deployment diagram (Kubernetes)" width="600">
+<img src="docs/diagrams/out/c4-deployment.png" alt="C4 Deployment diagram (Kubernetes)" width="560">
 
 - Three pods in the `default` namespace, one per service (`pizza-store`, `pizza-kitchen`, `pizza-delivery`), each running a single replica with matching `dapr.io/app-id` annotations (`pizza-store`, `kitchen-service`, `delivery-service`).
 - Each pod co-locates the Spring Boot app container with a Dapr sidecar injected via the `dapr.io/enabled` annotation. Cross-pod service invocation flows app → local sidecar → remote sidecar → remote app over mTLS HTTP/gRPC; apps never address each other directly.


### PR DESCRIPTION
`/architecture-diagrams` review (self-review-bias guard **active** — re-derived every C4 tech-string from current build files).

## Review result: compliant on every important axis
- **Tech-strings accurate** vs current ground truth: Spring Boot **4.0.7**, Dapr runtime **1.17.7** / SDK **1.17.2**, K8s **v1.36+** — all match `pom.xml`/`.mise.toml`/`Makefile` (synced earlier this session).
- C4-PlantUML `!include` pinned to **v2.13.0** (tagged); `plantuml/plantuml` + `minlag/mermaid-cli` Renovate-annotated.
- Security grep **clean**; element counts **≤15** (context 5, container 9, deployment 10); `diagrams-check` **drift-clean**; `mermaid-lint` green; both gates wired into `static-check`.
- The new **shared-sidecar topology is intentionally NOT in the C4 diagrams** — per the alternate-topology doc pattern, the project diagrams depict the default topology and the alternate is documented in `k8s-dapr-shared/README.md`.

## The one finding (MEDIUM): oversized rendered heights
All `<img width>` values were already ≤ the PNG's intrinsic width (no upscaling/blur), but rendered heights exceeded the ~500px guideline. Fixed:
| Diagram | width | rendered height |
|---------|-------|-----------------|
| c4-context (hero) | 240→**220** | 526→**482px** ✓ |
| c4-deployment | 600→**560** | 530→**495px** ✓ |
| c4-container | 520→**440** | 927→**784px** (still tall) |

c4-container stays >500px because its source is a **708×1262 portrait** — hitting ≤500px needs an unreadably small width. The proper fix is a  layout pass (deliberate visual-design change), noted for a follow-up; this PR is the safe width reduction.

Docs-only (3 width attrs). mermaid-lint green.