### PR TITLE
fix(make): repair cve-check recipe continuation broken by #100

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -416,6 +416,20 @@ cve-check: deps-check
 	@# bad-auth) and which -DossIndexAnalyzerWarnOnlyOnRemoteErrors does NOT
 	@# catch. If cve-check starts failing on OSS Index 401s, slim the tree, move
 	@# to a paid tier, or set -DossindexAnalyzerEnabled=false with a rationale.
+	@# Self-heal a corrupt NVD H2 cache. actions/cache tars odc.mv.db; if a
+	@# prior NVD update was interrupted (cancelled/timeout) or the file was
+	@# archived before H2 flushed, the cached .mv.db is TRUNCATED and every
+	@# subsequent run restore-keys re-hydrates the poison, hard-failing with
+	@# `MVStoreException: ... length -1` -> `connectionPool ... is null` NPE
+	@# cascade -> Maven exit 2 (root cause of scheduled run 27938409200,
+	@# 2026-06-22). dependency-check does NOT auto-recover; `purge` (delete the
+	@# H2 data dir) then a fresh download is the documented recovery
+	@# (purge-mojo.html, dependency-check/DependencyCheck#6115). The mvn block
+	@# below is ONE backslash-continued shell line (NO @# comments inside it —
+	@# they splice into the continuation and break it): on the corruption
+	@# signature it purges + re-runs ONCE; a REAL CVE finding still fails fast
+	@# (failOnError=false would wrongly swallow real findings too). pipefail so
+	@# the gate reads mvn's rc, not tee's (SHELL := /bin/bash).
 	@mkdir -p $$HOME/.m2; \
 	SERVERS=""; NVD_FLAG=""; OSS_FLAG="-DossindexAnalyzerEnabled=false"; \
 	if [ -n "$$NVD_API_KEY" ]; then \
@@ -427,18 +441,6 @@ cve-check: deps-check
 		OSS_FLAG="-DossIndexServerId=ossindex"; \
 	fi; \
 	( umask 077 && printf '<settings><servers>%s</servers></settings>\n' "$$SERVERS" > $$HOME/.m2/settings.xml ); \
-	@# Self-heal a corrupt NVD H2 cache. actions/cache tars odc.mv.db; if a
-	@# prior NVD update was interrupted (cancelled/timeout) or the file was
-	@# archived before H2 flushed, the cached .mv.db is TRUNCATED and every
-	@# subsequent run restore-keys re-hydrates the poison, hard-failing with
-	@# `MVStoreException: ... length -1` → `connectionPool ... is null` NPE
-	@# cascade → Maven exit 2 (root cause of scheduled run 27938409200,
-	@# 2026-06-22). dependency-check does NOT auto-recover; `purge` (delete the
-	@# H2 data dir) then a fresh download is the documented recovery
-	@# (purge-mojo.html, dependency-check/DependencyCheck#6115). Bounded to ONE
-	@# retry, and gated on the corruption signature so a REAL CVE finding still
-	@# fails fast (failOnError=false would wrongly swallow real findings too).
-	@# pipefail so the gate reads mvn's rc, not tee's (SHELL := /bin/bash).
 	set -o pipefail; LOG=$$(mktemp); \
 	if mvn -B org.owasp:dependency-check-maven:check $$NVD_FLAG $$OSS_FLAG 2>&1 | tee "$$LOG"; then \
 		rm -f "$$LOG"; \


### PR DESCRIPTION
## What broke

PR #100's NVD-cache self-heal inserted `@#` comment lines **inside** the backslash-continued shell block of the `cve-check` Makefile recipe. Make splices a `\`-terminated line into the next, so the comment text (`...tars odc.mv.db; if a`) spliced a dangling `if` into the shell command, and the logical line died:

```
/bin/bash: -c: line 13: syntax error: unexpected end of file
make: *** [Makefile:419: cve-check] Error 2
```

The post-merge `workflow_dispatch` run [27974154831](https://github.com/AndriyKalashnykov/dapr-java/actions/runs/27974154831) failed `cve-check` in **11 seconds** — a self-inflicted break from #100, not the original H2 corruption (which #100 otherwise fixes correctly: cache key `nvd-db-v2-` + purge/retry logic).

## Why it slipped through

- `make -n cve-check` prints the recipe but **does not run bash**, so it can't surface a shell syntax error.
- The isolated branch-logic test exercised the shell logic but not Make's line-continuation/comment interaction.

## Fix

Move the explanatory comments to the standalone `@#` header (before the continued block); the `mvn` self-heal stays as **one pure `\`-continued shell line** with no `@#` lines inside it.

## Test plan

- [x] `bash -n` on the `make -n`-rendered recipe → **PARSE OK** (definitive, execution-independent).
- [x] Real `make cve-check` run exercised the purge/retry branch with **no syntax error**.
- [ ] Post-merge `workflow_dispatch` runs `cve-check` to terminal on the fresh `nvd-db-v2-` key (will verify after merge).