### PR TITLE
fix(ci): cve-check classifier — 503 must win over shared corrupt consequence

### DIFF
--- a/scripts/cve-check.sh
+++ b/scripts/cve-check.sh
@@ -26,16 +26,27 @@
 set -euo pipefail
 
 # --- classifiers: single source of truth (mutation-proven by --self-test) ---
-# Order of evaluation in classify(): real-cve > corrupt > update-fail.
+# Evaluation order is precedence-critical (see classify()):
+#   real-cve  >  corrupt(primary)  >  update-fail  >  corrupt(consequence)
+# `MVStoreException` is the ONLY unambiguous file-corruption marker, so it is
+# checked first. `connectionPool ... is null` / `NoDataException` are SHARED
+# consequences — they appear both on true corruption AND on a 503-against-an-
+# empty-cache (no data downloaded -> no connection pool). So the 503/update-
+# fail signature is checked BEFORE those consequence markers; otherwise a
+# transient outage on a fresh cache is mislabeled "corrupt" and takes a
+# pointless purge. A healthy populated DB during a 503 yields NO consequence
+# markers, so the populated-cache graceful-degradation path is unaffected.
 REAL_CVE_RE='identified with vulnerabilit|CVSS score greater than or equal|One or more dependencies were identified'
-CORRUPT_RE='MVStoreException|connectionPool.*is null|NoDataException'
+CORRUPT_PRIMARY_RE='MVStoreException'
 UPDATE_FAIL_RE='NVD Returned Status Code: 503|Error updating the NVD Data|Unable to (update|continue).*(NVD|dependency-check)'
+CORRUPT_CONSEQUENCE_RE='connectionPool.*is null|NoDataException'
 
 classify() { # reads log text on stdin, echoes: real-cve | corrupt | update-fail | unknown
   local log; log=$(cat)
   if printf '%s' "$log" | grep -qiE "$REAL_CVE_RE"; then echo real-cve
-  elif printf '%s' "$log" | grep -qiE "$CORRUPT_RE"; then echo corrupt
+  elif printf '%s' "$log" | grep -qiE "$CORRUPT_PRIMARY_RE"; then echo corrupt
   elif printf '%s' "$log" | grep -qiE "$UPDATE_FAIL_RE"; then echo update-fail
+  elif printf '%s' "$log" | grep -qiE "$CORRUPT_CONSEQUENCE_RE"; then echo corrupt
   else echo unknown; fi
 }
 
@@ -54,6 +65,13 @@ if [ "${1:-}" = "--self-test" ]; then
   expect "unclassified"          "[INFO] BUILD SUCCESS" unknown
   # A real CVE during a partial update must classify as real-cve, not update-fail.
   expect "real-CVE wins vs 503"  "NVD Returned Status Code: 503 ... One or more dependencies were identified with vulnerabilities" real-cve
+  # 503 on an EMPTY cache emits the connectionPool-null consequence too; the
+  # 503 (update-fail) signature must win over the shared consequence marker,
+  # NOT be mislabeled corrupt (regression guard for run 27980148435).
+  expect "503+connPool -> update-fail" 'NVD Returned Status Code: 503 ... NullPointerException: ... because "this.connectionPool" is null' update-fail
+  # True file corruption (MVStoreException) WITHOUT a 503 stays corrupt even
+  # though it also carries the connectionPool-null consequence.
+  expect "MVStore wins vs consequence" 'org.h2.mvstore.MVStoreException: length -1 ... connectionPool ... is null' corrupt
   [ "$rc" -eq 0 ] && echo "cve-check.sh --self-test: PASS" || echo "cve-check.sh --self-test: FAIL"
   exit "$rc"
 fi


### PR DESCRIPTION
## What this fixes

Follow-up to #102. The best-effort dispatch [27980148435](https://github.com/AndriyKalashnykov/dapr-java/actions/runs/27980148435) revealed a classifier precedence bug: a **503 against an empty cache** was mislabeled **`corrupt`** and took a pointless `purge` branch:

```
NvdApiException: NVD Returned Status Code: 503
==> cve-check: corrupt NVD H2 cache — purging...   ← wrong branch
```

**Cause:** a 503 on a fresh/empty NVD cache emits *both* the 503 string *and* a `connectionPool null` / `NoDataException` cascade (no data downloaded → no connection pool). `classify()` checked the corrupt signature (which lumped in those consequence markers) **before** the 503/update-fail signature.

**Fix:** `MVStoreException` is the only *unambiguous* file-corruption marker; `connectionPool null` / `NoDataException` are *shared consequences*. New precedence:

```
real-cve  >  corrupt(MVStoreException)  >  update-fail(503)  >  corrupt(consequence)
```

- transient 503 on a fresh cache → **`update-fail`** (accurate message, no wasted purge)
- true file corruption (`MVStoreException`) → still **`corrupt`** → purge+retry
- populated-cache 503 graceful degradation → **unaffected** (a healthy DB emits no consequence markers)

The empty-cache+503 *outcome* was already `fail` (no cached DB); this corrects the branch taken, the diagnostic message, and mixed-signal precedence.

## Test plan
- [x] `bash -n` + **shellcheck** clean.
- [x] `--self-test` **9/9**, including two new regression guards: `503+connPool → update-fail` and `MVStore wins vs consequence`.
- [x] Stubbed 503-on-empty-cache run now takes `update-fail`/no-cache branch (no purge), correct message.
- [x] Self-test runs in `static-check` (this PR's CI exercises it).