### PR TITLE
fix(deps): bump jackson 3.1.3 → 3.1.4 (CVE-2026-54512/54513)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -35,8 +35,8 @@
         <grpc.version>1.81.0</grpc.version>
         <protobuf-java.version>4.35.0</protobuf-java.version>
         <tomcat.version>11.0.22</tomcat.version>
-        <jackson.version>3.1.3</jackson.version>
-        <jackson-bom.version>3.1.3</jackson-bom.version>
+        <jackson.version>3.1.4</jackson.version>
+        <jackson-bom.version>3.1.4</jackson-bom.version>
         <netty.version>4.2.15.Final</netty.version>
     </properties>
 
@@ -81,7 +81,12 @@
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>
-            <!-- CVE overrides: force fixed versions ahead of Spring Boot BOM -->
+            <!-- CVE overrides: force fixed versions ahead of Spring Boot BOM.
+                 jackson (tools.jackson.core, Jackson 3.x) pinned to 3.1.4 ahead
+                 of the SB 4.0.7 BOM (ships 3.1.3) to close CVE-2026-54512 /
+                 CVE-2026-54513 (jackson-databind PolymorphicTypeValidator bypass
+                 → arbitrary code execution, both HIGH). Surfaced by image-scan /
+                 cve-check. Drop the override once the SB BOM ships >= 3.1.4. -->
             <dependency>
                 <groupId>org.apache.tomcat.embed</groupId>
                 <artifactId>tomcat-embed-core</artifactId>


### PR DESCRIPTION
## Problem

The scheduled `CI` runs on `main` have been RED (runs 28775468747, 28356638342 — both `schedule` events; the last `push` run was green). All three `image-scan` matrix jobs (`pizza-store`, `pizza-kitchen`, `pizza-delivery`) fail **identically** — the "N jobs failing identically → diagnose main" signal.

Root cause: **`tools.jackson.core:jackson-databind` 3.1.3** (Jackson 3.x, bundled in every service image) is flagged HIGH by trivy for two freshly-disclosed CVEs, both fixed in **3.1.4**:

- **CVE-2026-54512** — jackson-databind PolymorphicTypeValidator bypass → arbitrary code execution (HIGH)
- **CVE-2026-54513** — jackson-databind security-bypass → arbitrary code execution (HIGH)

Jackson is **explicitly pinned** in the parent pom (`jackson.version` / `jackson-bom.version` = 3.1.3) as a CVE override ahead of the Spring Boot 4.0.7 BOM (which ships 3.1.3), so Renovate's BOM tracking didn't surface the bump — this was a stale manual override. No open Renovate PR; the fix belongs on `main` directly.

## Fix

Bump both `jackson.version` and `jackson-bom.version` `3.1.3 → 3.1.4` and annotate the override with the CVE rationale + drop-condition.

## Verification (RED → GREEN, real image scan)

- **RED (before):** `trivy image` on the cached `pizza-store:e2e` (jackson 3.1.3) flagged CVE-2026-54512/54513 — reproduces the CI failure.
- **GREEN (after):** rebuilt `pizza-store:e2e` with jackson 3.1.4, `trivy image --severity HIGH,CRITICAL --ignore-unfixed --exit-code 1` → **exit 0**; `jackson-databind-3.1.4.jar` scans clean.
- Unit tests **17/17** green (incl. `OrderJsonTest` jackson round-trip).
- jackson-databind resolves to 3.1.4 (`mvn dependency:tree`); 3.1.4 GA on Maven Central.

Fixes the scheduled-CI red (`image-scan` + downstream `cve-check`/`ci-pass`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
