### PR TITLE
docs(e2e): fix stale websocat backend reference (cargo → aqua:vi/websocat)

### DIFF
--- a/e2e/e2e-test.sh
+++ b/e2e/e2e-test.sh
@@ -231,13 +231,13 @@ assert_status_in_range POST "$BASE/order" 400 499 'this is not json'
 # PUBLIC_IP-hardcoded WS bug retired 2026-04-26). Subscribes a STOMP client
 # to /topic/events through the LB-exposed /ws endpoint, places a fresh
 # order, and asserts at least one MESSAGE frame arrives. Skipped when
-# `websocat` isn't on PATH (mise installs `cargo:websocat`; bare hosts
+# `websocat` isn't on PATH (mise installs `aqua:vi/websocat`; bare hosts
 # without mise won't have it — soft-skip rather than fail to keep the
 # script portable across local debugging contexts).
 echo ""
 echo "=== WebSocket broadcast assertion ==="
 if ! command -v websocat >/dev/null 2>&1; then
-  echo "SKIP: websocat not on PATH (run 'mise install' to provision it). Add 'cargo:websocat' is in .mise.toml."
+  echo "SKIP: websocat not on PATH (run 'mise install' to provision it — pinned as 'aqua:vi/websocat' in .mise.toml)."
 else
   WS_LOG=$(mktemp)
   # STOMP CONNECT then SUBSCRIBE; sleep keeps the connection open while the


### PR DESCRIPTION
Trivial follow-up from `/test-coverage-analysis`. `e2e/e2e-test.sh`'s websocat skip-path comment + SKIP message named the wrong mise backend (`cargo:websocat`) and had a broken sentence ("Add 'cargo:websocat' is in .mise.toml"). `.mise.toml` pins `aqua:vi/websocat 1.14.1`.

Comment + echo string only — **no behavior change** (`bash -n` clean). Same drift class as the CLAUDE.md fix in #108.

🤖 Generated with [Claude Code](https://claude.com/claude-code)