### PR TITLE
chore(renovate): complete kindest/node digest-collision guard + mise aqua release-age buffer

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -215,6 +215,26 @@
         "docker"
       ],
       "pinDigests": false
+    },
+    {
+      "description": "kindest/node is digest-pinned (KIND_NODE_DIGEST) and its tags are immutable, so docker:pinDigests never has a legitimate digest to refresh — but it still generates a `digest` updateType that collides with the version bump in the grouped 'KinD stack' branch and silently drops it. `pinDigests: false` above covers only the `pinDigest` (pin-where-absent) updateType, NOT `digest` (refresh), so it does not stop this. Disable the standalone digest-refresh for kindest/node; a real version bump carries its own fresh digest via the customManager's currentDigest capture. See /renovate skill dapr-go-poly 2026-06-14.",
+      "matchPackageNames": [
+        "kindest/node"
+      ],
+      "matchUpdateTypes": [
+        "digest"
+      ],
+      "enabled": false
+    },
+    {
+      "description": "3-day stability buffer for aqua:-backend mise tools (websocat, container-structure-test). The mise manager resolves aqua: pins via the github-tags datasource, which sees a new git tag before the upstream GitHub Release artifacts that `mise install` downloads are published — a bump to a just-tagged-but-not-released version 404s in `mise install` and reddens deps/static-check. The buffer defers the PR until the release publishes. Scoped to github-tags so it does not touch kind/kubectl (core backend) or the Java pin.",
+      "matchManagers": [
+        "mise"
+      ],
+      "matchDatasources": [
+        "github-tags"
+      ],
+      "minimumReleaseAge": "3 days"
     }
   ]
 }


### PR DESCRIPTION
`/renovate` review follow-up to #108 (self-review-bias guard: I authored #108's renovate change).

## Findings fixed
- **HIGH** — #108 added a `currentDigest`-capturing customManager for `kindest/node` but not its companion digest-refresh guard. `pinDigests: false` covers only the `pinDigest` (pin-where-absent) updateType, **not** `digest` (refresh) — so the next K8s-minor bump would be silently dropped by a digest-refresh collision in the grouped `KinD stack` branch (documented dapr-go-poly 2026-06-14). Added `{matchPackageNames:[kindest/node], matchUpdateTypes:[digest], enabled:false}`. Provably harmless: kindest/node tags are immutable, so no legitimate digest-refresh ever exists.
- **MEDIUM** — no manager-wide `minimumReleaseAge` on the `mise` manager; `.mise.toml` has `aqua:` tools (websocat, container-structure-test) exposed to the tag-before-release 404 race. Added `{matchManagers:[mise], matchDatasources:[github-tags], minimumReleaseAge:"3 days"}`, scoped to `github-tags` so kind/kubectl (core) + the Java pin are unaffected.

## Verified
- `renovate-config-validator`: **Config validated successfully**; 20 packageRules (+2).

## Honest caveat
The kindest/node collision can't be demonstrated **live** until a kindest/node version newer than `v1.36.1` exists to trigger it — the fix rests on the documented dapr-go-poly evidence + tag-immutability argument, not a demonstrated RED.

🤖 Generated with [Claude Code](https://claude.com/claude-code)