### PR TITLE
fix(readme): replace broken hits.sh badge with visitor-badge.laobi.icu

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 [![CI](https://github.com/AndriyKalashnykov/dapr-java/actions/workflows/ci.yml/badge.svg?branch=main)](https://github.com/AndriyKalashnykov/dapr-java/actions/workflows/ci.yml)
-[![Hits](https://hits.sh/github.com/AndriyKalashnykov/dapr-java.svg?view=today-total&style=plastic)](https://hits.sh/github.com/AndriyKalashnykov/dapr-java/)
+[![Visitors](https://visitor-badge.laobi.icu/badge?page_id=AndriyKalashnykov.dapr-java)](https://github.com/AndriyKalashnykov/dapr-java)
 [![License: Apache-2.0](https://img.shields.io/badge/License-Apache%202.0-brightgreen.svg)](https://opensource.org/licenses/Apache-2.0)
 [![Renovate enabled](https://img.shields.io/badge/renovate-enabled-brightgreen.svg)](https://app.renovatebot.com/dashboard#github/AndriyKalashnykov/dapr-java)
 


### PR DESCRIPTION
## Problem

The **Hits** badge renders as a broken image on the repo page. Verified end-to-end:

- In the browser DOM the Hits `<img>` (Camo-proxied) has `naturalWidth: 0`; CI / License / Renovate all load fine.
- GitHub's Camo proxy returns **HTTP 502** for the badge.
- Upstream root cause: **hits.sh serves an incomplete TLS chain** — after a same-day Let's Encrypt renewal (`notBefore` = today) its old `Apache/2.4.38 (Win64) OpenSSL/1.1.1b` box presents only the leaf cert, **missing the LE intermediate** (`openssl s_client` → `Verify return code: 20`). Camo validates TLS strictly, so it can't fetch it → 502 → broken image.

The badge markdown was valid; the failure is entirely upstream.

## Fix

Replace hits.sh with **visitor-badge.laobi.icu** — a per-repo (`page_id`) visitor counter, the same metric. Verified before committing:

- TLS chain valid: `openssl s_client` → `Verify return code: 0 (ok)` (the exact property that broke hits.sh).
- Returns `200 image/svg+xml`.

So Camo will proxy it successfully.

## Verification

Post-merge: reload the repo page and confirm the new badge's `naturalWidth > 0` (Camo 200).