### PR TITLE
docs(readme): render Deployment View at 100% width to match Order Flow

### DIFF
--- a/README.md
+++ b/README.md
@@ -153,7 +153,7 @@ sequenceDiagram
 
 ### Deployment View
 
-<img src="docs/diagrams/out/c4-deployment.png" alt="C4 Deployment diagram (Kubernetes)" width="560">
+<img src="docs/diagrams/out/c4-deployment.png" alt="C4 Deployment diagram (Kubernetes)" width="100%">
 
 - Three pods in the `default` namespace, one per service (`pizza-store`, `pizza-kitchen`, `pizza-delivery`), each running a single replica with matching `dapr.io/app-id` annotations (`pizza-store`, `kitchen-service`, `delivery-service`).
 - Each pod co-locates the Spring Boot app container with a Dapr sidecar injected via the `dapr.io/enabled` annotation. Cross-pod service invocation flows app → local sidecar → remote sidecar → remote app over mTLS HTTP/gRPC; apps never address each other directly.


### PR DESCRIPTION
The Deployment View PNG was pinned at `width=560` while the **Order Flow** Mermaid diagram renders at `width=100%` (fills the README column). Set the Deployment `<img>` to `width=100%` so both render at the same full-column width.

- PNG intrinsic is 1130px ≥ the ~1012px README column → downscales, no upscaling (satisfies the `/architecture-diagrams` no-upscale rule).
- No PNG re-render — display-width attribute only.