### PR TITLE
ci: add .mise.toml + .zap/** to the e2e paths filter (hole opened by dropping the main-push e2e)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -93,6 +93,18 @@ jobs:
             - '.github/workflows/ci.yml'
             - 'e2e/**'
             - 'scripts/**'
+            # `.mise.toml` pins the ENTIRE e2e toolchain — kind, kubectl, helm,
+            # websocat. A Renovate bump to any of them can break `make e2e` while
+            # touching no Java, no manifest, and no script. This used to be caught
+            # by the merge-to-main e2e run; that run is gone (squash-merge makes it
+            # a duplicate of the PR run), so without this filter entry a bad kind /
+            # kubectl / helm bump would reach `main` with e2e never having run on
+            # it, and surface only on the weekly cron — days later, on someone
+            # else's change.
+            - '.mise.toml'
+            # e2e ends with a STRICT OWASP ZAP baseline scan gated by these rules;
+            # editing the ignore list changes whether e2e passes.
+            - '.zap/**'
 
   static-check:
     needs: [changes]


### PR DESCRIPTION
## A hole that #117 opened, found by auditing what "drop the main-push e2e" actually cost

**`.mise.toml` pins the entire e2e toolchain** — `kind 0.32.0`, `kubectl 1.36.2`, `helm 4.2.0`, `websocat` — and it was **not in the `e2e` paths filter**. A Renovate bump to any of those can break `make e2e` while touching no Java, no manifest, and no script.

That was survivable while `e2e` *also* ran on every push to `main`: a bad bump merged, and the main-push run caught it on the spot. #117 removed that run (with squash-merge it re-tested a tree byte-identical to the PR head — the right call for the minutes budget), which **silently turned this into a real hole**: a bad `kind`/`kubectl`/`helm` bump would now reach `main` with e2e having **never run on it**, and surface only on the weekly cron — days later, attributed to somebody else's unrelated change.

Also adds **`.zap/**`**: `e2e` ends with a *strict* OWASP ZAP baseline scan gated by `.zap/rules.tsv`, so editing that ignore list directly changes whether e2e passes.

## Cost

Nil in the common case. These paths change only on a Renovate toolchain bump or a deliberate ZAP-rule edit — precisely the changes that *should* pay for an e2e.

## Test plan

- [x] `actionlint` clean
- [x] `make static-check` green
- [ ] **Not verified end-to-end.** A `.mise.toml`-only diff needs a PR of its own to exercise the new entry — this PR's own diff touches `ci.yml`, which already matches the `e2e` filter, so it cannot isolate it. I tried to isolate it locally under `act` and `dorny/paths-filter` misreported the diff inside act's workspace, so I stopped rather than trust a tool that was giving wrong answers. Follow-up probe PR (a one-line `.mise.toml` comment) will confirm `changes` emits `e2e=true`; I'll cancel it as soon as the `changes` job reports, so it costs ~1 minute.

Corroborating evidence in the meantime: the same filter list already contains `.github/workflows/ci.yml` — a dot-prefixed literal path — and that entry demonstrably matches (observed in an `act` run of the `changes` job). `.mise.toml` is the identical pattern class.
