### PR TITLE
PROBE — do not merge: verify .mise.toml triggers the e2e filter

### DIFF
--- a/.mise.toml
+++ b/.mise.toml
@@ -32,3 +32,5 @@ kubeconform = "0.7.0"
 # only surface at runtime. Driven by `make image-test` and the CI
 # `image-scan` job's Structure test step. Used by /image-test.
 "aqua:GoogleContainerTools/container-structure-test" = "1.22.1"
+
+# probe: verifying .mise.toml triggers the e2e paths filter (PR will be closed)


### PR DESCRIPTION
Throwaway probe. Diff is a single comment line in `.mise.toml`. Purpose: confirm the `changes` job emits `e2e=true` for a .mise.toml-only diff (the filter entry added in #119, which I could not verify locally because act misreported the diff). Will be cancelled + closed as soon as `changes` reports.